### PR TITLE
ignore more autotools files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@ junk*
 build/
 cscope.files
 TAGS
+
+# autotools ignore
+*.lo
+*.la
+Makefile
+config.h
+config.log
+config.status
+libtool
+stamp-h1
+libdwarf/libdwarf.h
+autom4te.cache/
+.deps/
+.libs/


### PR DESCRIPTION
'git status' reports files generated with configure or make. This commit removes them from the status report.