### PR TITLE
Allow choosing an MSVC runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.15)
 
 project(libdwarf C CXX)
 
@@ -13,6 +13,19 @@ macro(msvc_posix target)
 	    snprintf=_snprintf)
     endif()
 endmacro()
+
+set(LIBDWARF_CRT "MD" CACHE STRING "Either MT or MD, specifies whether to use the static or dynamic MSVCRT.")
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Check MSVCRT option and set flags accordingly
+  if (LIBDWARF_CRT STREQUAL "MT")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug, RelWithDebInfo>:Debug>")
+  elseif(LIBDWARF_CRT STREQUAL "MD")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug, RelWithDebInfo>:Debug>DLL")
+  else()
+    message(FATAL_ERROR "LIBDWARF_CRT must be MT or MD")
+  endif()
+endif()
 
 # set target folder on IDE
 macro(set_folder target folder)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ To build using CMake one might do
 * build: `cmake --build _Release --target dd`
 * (optionally install): `sudo cmake --build _Release --target install`
 
+## CMake Options
+- `BUILD_DWARFEXAMPLE` - builds dwarfexample when `ON`
+- `BUILD_DWARFGEN` - builds dwarfgen when `ON`
+- `LIBDWARF_CRT` - either `MD` or `MT`, by default `MD`. Sets the MSVC runtime used by libdwarf, debug symbols will be used in debug builds.
+
 # for autotools builds, see README
 
 ### Using autotools
@@ -81,4 +86,3 @@ a build and then
   make dist
 
 David Anderson. 
-


### PR DESCRIPTION
This also bumps CMake to version 3.15. Might be able to keep the 3.2 versions using some version checks and whatnot.