### PR TITLE
Fix "function declaration isn't a prototype" warning 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ check_include_file( "elf.h"           HAVE_ELF_H      )
 check_include_file( "libelf.h"        HAVE_LIBELF_H   ) 
 check_include_file( "libelf/libelf.h" HAVE_LIBELF_LIBELF_H) 
 check_include_file( "alloca.h"        HAVE_ALLOCA_H   )
-check_include_file( "elfaccess.h"     HAVE_ELFACCESS_H)
 
 ### cmake provides no way to guarantee uint32_t present.
 ### configure does guarantee that.

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -33,9 +33,6 @@
 /* Set to 1 if the elf64_getshdr function is in libelf. */
 #cmakedefine HAVE_ELF64_GETSHDR 1
 
-/* Define to 1 if you have the <elfaccess.h> header file. */
-#cmakedefine HAVE_ELFACCESS_H 1
-
 /* Define to 1 if you have the <elf.h> header file. */
 #cmakedefine HAVE_ELF_H 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -180,7 +180,7 @@ CPPFLAGS_save=${CPPFLAGS}
 
 if test  "$dwarf_with_libelf" = "yes" ; then
   AC_CHECK_HEADERS([libelf.h libelf/libelf.h])
-  AC_CHECK_HEADERS([elf.h elfaccess.h])
+  AC_CHECK_HEADERS([elf.h])
 
   ### if no libelf.h add no -lelf and turn off
   ### libelf recognition.

--- a/src/bin/dwarfdump/print_die.c
+++ b/src/bin/dwarfdump/print_die.c
@@ -475,7 +475,7 @@ check_die_expr_op_basic_data(Dwarf_Debug dbg,Dwarf_Die die,
     offset in the stack.  Or 0 if we have none known.
 */
 static Dwarf_Off
-get_die_stack_sibling()
+get_die_stack_sibling(void)
 {
     int i = die_stack_indent_level;
     for ( ; i >=0 ; --i)
@@ -585,7 +585,7 @@ append_local_prefix(struct esb_s *esbp)
     esb_append(esbp,"\n      ");
 }
 static int
-print_as_info_or_by_cuname()
+print_as_info_or_by_cuname(void)
 {
     return (glflags.gf_info_flag || glflags.gf_types_flag
         || glflags.gf_cu_name_flag);

--- a/src/bin/dwarfdump/print_macro.c
+++ b/src/bin/dwarfdump/print_macro.c
@@ -107,7 +107,7 @@ macdef_tree_destroy_inner( void *tree)
     dwarf_tdestroy(tree,macdef_free_func);
 }
 static void
-destroy_macdef_tree()
+destroy_macdef_tree(void)
 {
     macdef_tree_destroy_inner(macdefundeftree);
     macdefundeftree = 0;

--- a/src/lib/libdwarfp/dwarf_pro_arange.c
+++ b/src/lib/libdwarfp/dwarf_pro_arange.c
@@ -35,9 +35,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif
 #include "dwarf_pro_incl.h"
 #include <stddef.h>
 #include "dwarf.h"

--- a/src/lib/libdwarfp/dwarf_pro_dnames.c
+++ b/src/lib/libdwarfp/dwarf_pro_dnames.c
@@ -38,9 +38,6 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h> /* for exit(), C89 malloc */
 #endif /* HAVE_STDLIB_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif /* HAVE_ELFACCESS_H */
 #include "dwarf_pro_incl.h"
 #include <stddef.h>
 #include "dwarf.h"

--- a/src/lib/libdwarfp/dwarf_pro_funcs.c
+++ b/src/lib/libdwarfp/dwarf_pro_funcs.c
@@ -33,9 +33,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif /* HAVE_ELFACCESS_H */
 #include "dwarf_pro_incl.h"
 #include <stddef.h>
 #include "dwarf.h"

--- a/src/lib/libdwarfp/dwarf_pro_pubnames.c
+++ b/src/lib/libdwarfp/dwarf_pro_pubnames.c
@@ -33,9 +33,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif
 #include <stddef.h>
 #include "libdwarf_private.h"
 #include "dwarf_pro_incl.h"

--- a/src/lib/libdwarfp/dwarf_pro_reloc_stream.c
+++ b/src/lib/libdwarfp/dwarf_pro_reloc_stream.c
@@ -32,13 +32,9 @@
 #ifdef DWARF_WITH_LIBELF
 #include "libdwarf_private.h"
 #include <stdio.h>
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#else
 /* Set r_info  as defined by ELF generic ABI */
 #define Set_REL32_info(r,s,t) ((r).r_info = ELF32_R_INFO(s,t))
 #define Set_REL64_info(r,s,t) ((r).r_info = ELF64_R_INFO(s,t))
-#endif
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */

--- a/src/lib/libdwarfp/dwarf_pro_reloc_symbolic.c
+++ b/src/lib/libdwarfp/dwarf_pro_reloc_symbolic.c
@@ -36,7 +36,6 @@
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>
 #endif /* HAVE_STDDEF_H */
-/*#include <elfaccess.h> */
 #include "dwarf_pro_incl.h"
 #include "dwarf.h"
 #include "libdwarfp.h"

--- a/src/lib/libdwarfp/dwarf_pro_section.c
+++ b/src/lib/libdwarfp/dwarf_pro_section.c
@@ -35,9 +35,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef   HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif

--- a/src/lib/libdwarfp/dwarf_pro_types.c
+++ b/src/lib/libdwarfp/dwarf_pro_types.c
@@ -33,9 +33,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif
 #include "dwarf_pro_incl.h"
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>

--- a/src/lib/libdwarfp/dwarf_pro_vars.c
+++ b/src/lib/libdwarfp/dwarf_pro_vars.c
@@ -34,9 +34,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif
 #include "dwarf_pro_incl.h"
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>

--- a/src/lib/libdwarfp/dwarf_pro_weaks.c
+++ b/src/lib/libdwarfp/dwarf_pro_weaks.c
@@ -34,9 +34,6 @@
 #ifdef HAVE_STRING_H
 #include <string.h>
 #endif /* HAVE_STRING_H */
-#ifdef HAVE_ELFACCESS_H
-#include <elfaccess.h>
-#endif /*  HAVE_ELFACCESS_H */
 #ifdef HAVE_STDDEF_H
 #include <stddef.h>
 #endif /* HAVE_STDDEF_H */


### PR DESCRIPTION

        modified:   src/bin/dwarfdump/print_die.c
        modified:   src/bin/dwarfdump/print_macro.c

Remove useless elfaccess.h header file

        modified:   CMakeLists.txt
        modified:   cmake/config.h.cmake
        modified:   configure.ac
        modified:   src/lib/libdwarfp/dwarf_pro_arange.c
        modified:   src/lib/libdwarfp/dwarf_pro_dnames.c
        modified:   src/lib/libdwarfp/dwarf_pro_funcs.c
        modified:   src/lib/libdwarfp/dwarf_pro_pubnames.c
        modified:   src/lib/libdwarfp/dwarf_pro_reloc_stream.c
        modified:   src/lib/libdwarfp/dwarf_pro_reloc_symbolic.c
        modified:   src/lib/libdwarfp/dwarf_pro_section.c
        modified:   src/lib/libdwarfp/dwarf_pro_types.c
        modified:   src/lib/libdwarfp/dwarf_pro_vars.c
        modified:   src/lib/libdwarfp/dwarf_pro_weaks.c
