### PR TITLE
Fix one more "function declaration isn't a prototype" warning in

### DIFF
--- a/src/bin/dwarfdump/print_ranges.c
+++ b/src/bin/dwarfdump/print_ranges.c
@@ -303,7 +303,7 @@ release_range_array_info()
 
 /*  Clear out values from previous CU */
 static void
-reset_range_array_info()
+reset_range_array_info(void)
 {
     if (range_array) {
         memset((void *)range_array,0,


### PR DESCRIPTION
dwarfdump

     modified:   ../src/bin/dwarfdump/print_ranges.c