### PR TITLE
fix tests compilation with meson

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -63,7 +63,7 @@ tests = [
   ],
   [
    'test_safe_strcpy.c',
-   '../src/bin/dwarfdump/dd_safe_strcpy.c',
+   '../src/lib/libdwarf/dwarf_safe_strcpy.c',
   ],
   [
    'test_regex.c',

--- a/test/test_linkedtopath.c
+++ b/test/test_linkedtopath.c
@@ -29,46 +29,16 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 
-#include "config.h"
-#include <stdio.h>
-#ifdef HAVE_STDLIB_H
-#include <stdlib.h>
-#endif /* HAVE_STDLIB_H */
-#ifdef HAVE_MALLOC_H
-/* Useful include for some Windows compilers. */
-#include <malloc.h>
-#endif /* HAVE_MALLOC_H */
-#include <string.h>
-#ifdef HAVE_ELF_H
-#include <elf.h>
-#endif /* HAVE_ELF_H */
+#include <config.h>
 
-#if defined(_WIN32)
-#include <io.h>
-#else
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-#endif /* defined(_WIN32) */
-
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h> /* open(), off_t, size_t, ssize_t */
-#endif /* HAVE_SYS_TYPES_H */
-#include <sys/stat.h> /* for open() */
-#include <fcntl.h> /* for open() */
-#include <errno.h>
-#if defined(_WIN32) && defined(HAVE_STDAFX_H)
-#include "stdafx.h"
-#endif /* HAVE_STDAFX_H */
-#ifdef HAVE_STRING_H
-#include <string.h>  /* strcpy() strlen() */
-#endif
-#ifdef HAVE_STDDEF_H
 #include <stddef.h>
-#endif
-#include "libdwarf_private.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "dwarf.h"
 #include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dwarf_base_types.h"
 #include "dwarf_safe_strcpy.h"
 #include "dwarf_opaque.h"

--- a/test/test_regex.c
+++ b/test/test_regex.c
@@ -62,7 +62,7 @@ testx(const char *expr,
 }
 
 int
-main()
+main(int argc, char *argv[])
 {
     testx("u.leb",DW_DLV_OK,"local_dwarf_decode_u",
         DW_DLV_NO_ENTRY,__LINE__);
@@ -145,4 +145,7 @@ main()
     }
     printf("PASS  test_regex\n");
     return 0;
+
+    (void)argc;
+    (void)argv;
 }


### PR DESCRIPTION
        modified:   test/meson.build
        modified:   test/test_linkedtopath.c
        modified:   test/test_regex.c