### PR TITLE
Replacing Windows PE section size sanity check.

### DIFF
--- a/src/lib/libdwarf/dwarf_peread.c
+++ b/src/lib/libdwarf/dwarf_peread.c
@@ -359,7 +359,7 @@ pe_load_section (void *obj, Dwarf_Half section_index,
         if (!sp->VirtualSize) {
             return DW_DLV_NO_ENTRY;
         }
-        if (sp->VirtualSize >= pep->pe_filesize) {
+        if (sp->SizeOfRawData >= pep->pe_filesize) {
             *error = DW_DLE_PE_SECTION_SIZE_ERROR;
             return DW_DLV_ERROR;
         }
@@ -526,14 +526,14 @@ dwarf_pe_load_dwarf_section_headers(
         sec_outp->SecHeaderOffset = cur_offset;
         ASNAR(pep->pe_copy_word,sec_outp->VirtualSize,
             filesect.Misc.VirtualSize);
-        if (sec_outp->VirtualSize >= pep->pe_filesize) {
-            *errcode = DW_DLE_PE_SECTION_SIZE_ERROR;
-            return DW_DLV_ERROR;
-        }
         ASNAR(pep->pe_copy_word,sec_outp->VirtualAddress,
             filesect.VirtualAddress);
         ASNAR(pep->pe_copy_word,sec_outp->SizeOfRawData,
             filesect.SizeOfRawData);
+        if (sec_outp->SizeOfRawData >= pep->pe_filesize) {
+            *errcode = DW_DLE_PE_SECTION_SIZE_ERROR;
+            return DW_DLV_ERROR;
+        }
         ASNAR(pep->pe_copy_word,sec_outp->PointerToRawData,
             filesect.PointerToRawData);
         if (sec_outp->SizeOfRawData > pep->pe_filesize ||


### PR DESCRIPTION
Removed in-memory size check, and replaced in with in-file size check.
Checking in-memory section size can trigger false positive result with large .bss sections.