### PR TITLE
Rename SELFTEST with TESTING. Also fix compilation of tests with the

### DIFF
--- a/src/bin/dwarfdump/dd_esb.c
+++ b/src/bin/dwarfdump/dd_esb.c
@@ -55,8 +55,8 @@
 /*  INITIAL_ALLOC value takes no account of space for a trailing NUL,
     the NUL is accounted for in init_esb_string
     and in later tests against esb_allocated_size. */
-#ifdef SELFTEST
-#define INITIAL_ALLOC 1  /* SELFTEST */
+#ifdef TESTING
+#define INITIAL_ALLOC 1  /* TESTING */
 #define MALLOC_COUNT 1
 #else
 /*  There is nothing magic about this size.

--- a/src/bin/dwarfdump/dd_macrocheck.c
+++ b/src/bin/dwarfdump/dd_macrocheck.c
@@ -90,10 +90,10 @@ static struct Macrocheck_Map_Entry_s * macrocheck_map_insert(
 static void macrocheck_map_destroy(void *map);
 static Dwarf_Unsigned macro_count_recs(void **base);
 
-#ifdef SELFTEST
+#ifdef TESTING
 int failcount = 0;
 struct glflags_s glflags;
-#endif /* SELFTEST */
+#endif /* TESTING */
 
 static struct Macrocheck_Map_Entry_s *
 macrocheck_map_create_entry(Dwarf_Unsigned offset,
@@ -345,7 +345,7 @@ qsort_compare(const void *lin, const void *rin)
 static void
 warnprimeandsecond(struct Macrocheck_Map_Entry_s *r)
 {
-#ifdef SELFTEST
+#ifdef TESTING
         ++failcount;
 #endif
     glflags.gf_count_major_errors++;
@@ -396,7 +396,7 @@ print_macrocheck_statistics(const char *name,void **tsbase,
     mac_as_array = (struct Macrocheck_Map_Entry_s **)calloc(count,
         sizeof(struct Macrocheck_Map_Entry_s *));
     if (!mac_as_array) {
-#ifdef SELFTEST
+#ifdef TESTING
         ++failcount;
 #endif
         glflags.gf_count_major_errors++;
@@ -432,7 +432,7 @@ print_macrocheck_statistics(const char *name,void **tsbase,
             highest = end;
         }
         if (r->mp_refcount_primary > 1) {
-#ifdef SELFTEST
+#ifdef TESTING
             ++failcount;
 #endif
             glflags.gf_count_major_errors++;
@@ -473,7 +473,7 @@ print_macrocheck_statistics(const char *name,void **tsbase,
             internalgap += (r->mp_key - lastend);
         } else if (r->mp_key < lastend) {
             /* crazy overlap */
-#ifdef SELFTEST
+#ifdef TESTING
             ++failcount;
 #endif
             glflags.gf_count_major_errors++;
@@ -502,7 +502,7 @@ print_macrocheck_statistics(const char *name,void **tsbase,
     wholegap = mac_as_array[0]->mp_key + internalgap;
     if (lastend > section_size) {
         /* Something seriously wrong */
-#ifdef SELFTEST
+#ifdef TESTING
         ++failcount;
 #endif
         printf(" ERROR: For offset 0x%" DW_PR_XZEROS DW_PR_DUx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-set(SELFTEST "-DSELFTEST")
 if (DO_TESTING)
     set_source_group(TESTSTRING "Source Files"
         ${CMAKE_SOURCE_DIR}/test/test_dwarfstring.c
@@ -92,19 +91,20 @@ if (DO_TESTING)
         "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
     add_test(NAME selfhelpertree COMMAND selfhelpertree)
 endif()
+
 if (DO_TESTING)
     set_source_group(SELFMC_SOURCES "Source Files"
       ${CMAKE_SOURCE_DIR}/test/test_macrocheck.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c 
+      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
       ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
     add_executable(selfmacrocheck ${SELFMC_SOURCES} )
-    target_compile_options(selfmacrocheck PRIVATE ${SELFTEST} )
+    target_compile_options(selfmacrocheck PRIVATE "-DTESTING" )
     target_compile_options(selfmacrocheck PRIVATE ${DW_FWALL})
-    target_compile_options(selfmacrocheck PRIVATE 
+    target_compile_options(selfmacrocheck PRIVATE
         "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
         "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
         "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
-    target_compile_options(selfmacrocheck PRIVATE 
+    target_compile_options(selfmacrocheck PRIVATE
         "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
     add_test(NAME selfmacrocheck COMMAND selfmacrocheck)
 endif()
@@ -121,7 +121,6 @@ if (DO_TESTING)
         "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
     target_compile_options(selftestesb PRIVATE
         "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
-    target_compile_options(selftestesb PRIVATE ${SELFTEST} )
     target_compile_options(selftestesb PRIVATE ${DW_FWALL})
     add_test(NAME selftestesb COMMAND selftestesb)
 endif()
@@ -130,8 +129,6 @@ if (DO_TESTING)
         ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_section_bitmaps.c
         ${CMAKE_SOURCE_DIR}/test/section_bitmaps_test.c )
     add_executable(selfsectionbitmaps ${SECTIONBITMAPS_SOURCES})
-    target_compile_options(selfsectionbitmaps PRIVATE
-        ${SELFTEST} )
     target_compile_options(selfsectionbitmaps PRIVATE ${DW_FWALL})
     target_compile_options(selfsectionbitmaps PRIVATE
         "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf")

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -80,6 +80,7 @@ test_linkedtopath_SOURCES = test_linkedtopath.c \
    $(top_srcdir)/src/lib/libdwarf/dwarf_error.h
 test_linkedtopath_CFLAGS =  $(DWARF_CFLAGS_WARN) -DTESTING
 test_linkedtopath_CPPFLAGS = -DTESTING \
+-DLIBDWARF_BUILD \
 -I$(top_srcdir) \
 -I$(top_builddir) \
 -I$(top_srcdir)/src/lib/libdwarf
@@ -115,7 +116,7 @@ test_macrocheck_SOURCES = test_macrocheck.c \
     $(top_srcdir)/src/bin/dwarfdump/dd_esb.c \
     $(top_srcdir)/src/bin/dwarfdump/dd_tsearchbal.c
 test_macrocheck_CFLAGS = $(DWARF_CFLAGS_WARN)
-test_macrocheck_CPPFLAGS =  -DSELFTEST \
+test_macrocheck_CPPFLAGS =  -DTESTING \
 -I$(top_srcdir) -I$(top_builddir) \
 -I$(top_srcdir)/src/bin/dwarfdump \
 -I$(top_srcdir)/src/lib/libdwarf
@@ -141,6 +142,7 @@ test_dwarflebtest_SOURCES = dwarf_leb_test.c \
     $(top_srcdir)/src/lib/libdwarf/dwarf_leb.c
 test_dwarflebtest_CFLAGS = $(DWARF_CFLAGS_WARN)
 test_dwarflebtest_CPPFLAGS = -DTESTING \
+-DLIBDWARF_BUILD \
 -I$(top_srcdir) -I$(top_builddir) \
 -I$(top_srcdir)/src/bin/dwarfdump \
 -I$(top_srcdir)/src/lib/libdwarf
@@ -157,6 +159,7 @@ test_getnametest_SOURCES = getnametest.c \
     $(top_srcdir)/src/lib/libdwarf/dwarf_names.c
 test_getnametest_CFLAGS = $(DWARF_CFLAGS_WARN)
 test_getnametest_CPPFLAGS = -DTESTING \
+-DLIBDWARF_BUILD \
 -I$(top_srcdir) -I$(top_builddir) \
 -I$(top_srcdir)/src/lib/libdwarf
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -83,7 +83,7 @@ foreach test_src : tests
   test_name = test_src[0].split('.')[0]
   test(test_name,
     executable(test_name, test_src,
-      c_args : [ dev_cflags, libdwarf_args, '-DTESTING', '-DSELFTEST', '-DLIBDWARF_BUILD' ],
+      c_args : [ dev_cflags, libdwarf_args, '-DTESTING', '-DLIBDWARF_BUILD' ],
       include_directories : [ config_dir, incdir ],
       install : false
     )


### PR DESCRIPTION
autotools on Windows

        modified:   src/bin/dwarfdump/dd_esb.c
        modified:   src/bin/dwarfdump/dd_macrocheck.c
        modified:   test/CMakeLists.txt
        modified:   test/Makefile.am
        modified:   test/meson.build