### PR TITLE
tests: reorganize headers

### DIFF
--- a/test/dwarf_leb_test.c
+++ b/test/dwarf_leb_test.c
@@ -27,20 +27,13 @@
 
 */
 
-#include "config.h"
-#include <stdio.h>
-#if defined(_WIN32) && defined(HAVE_STDAFX_H)
-#include "stdafx.h"
-#endif /* HAVE_STDAFX_H */
-#ifdef HAVE_STRING_H
-#include <string.h>  /* strcpy() strlen() */
-#endif
-#ifdef HAVE_STDDEF_H
-#include <stddef.h>
-#endif
-#include "libdwarf_private.h"
-#include "dwarf.h"
+#include <config.h>
+
+#include <stddef.h> /* size_t */
+#include <stdio.h>  /* printf() */
+
 #include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dwarf_base_types.h"
 #include "dwarf_opaque.h"
 #include "dwarf_error.h"
@@ -931,9 +924,7 @@ testatmaxlimit(void)
         ++errcnt;
     }
 
-
-
-    return errcnt; 
+    return errcnt;
 }
 
 int main(void)

--- a/test/dwarf_tied_test.c
+++ b/test/dwarf_tied_test.c
@@ -27,29 +27,23 @@
 
 */
 
-#include "config.h"
-#include <stdlib.h> /* for free(). */
-#include <stdio.h> /* For debugging. */
+#include <config.h>
+
+#include <stddef.h> /* size_t */
+#include <stdio.h>  /* printf() */
+#include <stdlib.h> /* exit() */
+#include <string.h> /* memcpy() memset() */
+
 #ifdef HAVE_STDINT_H
-#include <stdint.h> /* For uintptr_t */
+#include <stdint.h> /* uintptr_t */
 #endif /* HAVE_STDINT_H */
-#if defined(_WIN32) && defined(HAVE_STDAFX_H)
-#include "stdafx.h"
-#endif /* HAVE_STDAFX_H */
-#include <string.h>  /* strcpy() strlen() */
-#include <stddef.h>
-#include "libdwarf_private.h"
-#include "dwarf.h"
+
 #include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dwarf_base_types.h"
 #include "dwarf_opaque.h"
 #include "dwarf_tsearch.h"
 #include "dwarf_tied_decls.h"
-
-#define TRUE  1
-#define FALSE 0
-#define TRUE  1
-#define FALSE 0
 
 struct test_data_s {
     const char action;

--- a/test/getnametest.c
+++ b/test/getnametest.c
@@ -1,9 +1,13 @@
 /*  Copyright (c) 2021 David Anderson
     This test code is hereby placed in the public domain
     for anyone to use in any way.  */
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h> /* for exit() */
+
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <string.h> /* strcmp() */
+#include <stdlib.h> /* exit() */
+
 #include "dwarf.h"
 #include "libdwarf.h"
 

--- a/test/helpertree_test.c
+++ b/test/helpertree_test.c
@@ -25,21 +25,20 @@
 
 */
 
-#include "config.h"
-#include <stdio.h>
-#include <string.h> /* for strchr etc */
-#include <stdlib.h> /* for exit() */
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+
 #ifdef HAVE_STDINT_H
-#include <stdint.h>
+#include <stdint.h> /* uintptr_t */
 #endif /* HAVE_STDINT_H */
-#include "dwarf.h"
+
 #include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dd_globals.h"
 #include "dwarf_tsearch.h"
 #include "dd_helpertree.h"
 
-#define TRUE 1
-#define FALSE 0
 /*  WARNING: the tree walk functions will, if presented **tree
     when *tree is wanted, simply find nothing. No error,
     just bad results. So when a walk produces nothing

--- a/test/makename_test.c
+++ b/test/makename_test.c
@@ -38,14 +38,15 @@ Portions Copyright(C) David Anderson 2016. All Rights reserved.
    any normal case.
 */
 
-#include "config.h"
-#include <stdio.h>
-#include <string.h> /* for strchr etc */
-#include <stdlib.h> /* for exit() */
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <stdlib.h> /* exit() */
+
 #ifdef HAVE_STDINT_H
-#include <stdint.h>
+#include <stdint.h> /* uintptr_t */
 #endif /* HAVE_STDINT_H */
-#include "dwarf.h"
+
 #include "libdwarf.h"
 #include "dwarf_tsearch.h"
 #include "dd_makename.h"

--- a/test/section_bitmaps_test.c
+++ b/test/section_bitmaps_test.c
@@ -24,10 +24,11 @@
   Boston MA 02110-1301, USA.
 
 */
-#include "config.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include "dwarf.h"
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <stdlib.h> /* exit() */
+
 #include "libdwarf.h"
 #include "dd_globals.h"
 /*  section_bitmaps.h and .c actually involved  bits,

--- a/test/test_canonical.c
+++ b/test/test_canonical.c
@@ -4,15 +4,11 @@
   This trivial test program is hereby placed in the public domain.
 */
 
-#include "config.h"
-#include <stdio.h>
-#if defined(_WIN32) && defined(HAVE_STDAFX_H)
-#include "stdafx.h"
-#endif /* HAVE_STDAFX_H */
-#include <string.h>  /* strcpy() strlen() */
-#include <stddef.h>
-#include "dwarf.h"
-#include "libdwarf.h"
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <string.h>  /* strcmp() */
+
 #include "dd_canonical_append.h"
 
 #define CANBUF 25

--- a/test/test_dwarfstring.c
+++ b/test/test_dwarfstring.c
@@ -30,16 +30,15 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdio.h>  /* for printf */
-#include <stdlib.h>
-#include <string.h>
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <stdlib.h> /* exit() */
+#include <string.h> /* strcmp() strlen() */
+
+#include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dwarf_string.h"
-#ifndef TRUE
-#define TRUE 1
-#endif /* TRUE */
-#ifndef FALSE
-#define FALSE 0
-#endif /* FALSE */
 
 static int errcount;
 

--- a/test/test_errmsglist.c
+++ b/test/test_errmsglist.c
@@ -30,19 +30,15 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*  Usage:  ./test_errmsg_list.c
     where an env var gives path to source tree */
 
-#include "config.h"
-#include <stdio.h>
-#include <stdlib.h>  /* For exit(), strtoul() declaration etc. */
-#if defined(_WIN32) && defined(HAVE_STDAFX_H)
-#include "stdafx.h"
-#endif /* HAVE_STDAFX_H */
-#include <string.h>  /* strcpy() strlen() */
-#ifdef HAVE_STDDEF_H
-#include <stddef.h>
-#endif
-#include "libdwarf_private.h"
-#include "dwarf.h"
+#include <config.h>
+
+#include <stddef.h> /* size_t */
+#include <stdio.h>  /* FILE fclose() fgets() fopen() printf() */
+#include <stdlib.h> /* atol() exit() getenv() */
+#include <string.h> /* strcmp() strlen() strncmp() */
+
 #include "libdwarf.h"
+#include "libdwarf_private.h"
 #include "dwarf_base_types.h"
 #include "dwarf_safe_strcpy.h"
 #include "dwarf_opaque.h"

--- a/test/test_extra_flag_strings.c
+++ b/test/test_extra_flag_strings.c
@@ -29,16 +29,12 @@
     EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "config.h"
-#include <stdio.h>
-#include <string.h>
-#include <stddef.h>
-#ifdef HAVE_STDINT_H
-#include <stdint.h> /* For uintptr_t */
-#endif /* HAVE_STDINT_H */
-#include "dwarf.h"
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <string.h> /* memset() */
+
 #include "libdwarfp.h"
-#include "libdwarf_private.h"
 #include "dwarf_pro_incl.h"
 #include "dwarf_pro_opaque.h"
 #include "dwarf_string.h"

--- a/test/test_linkedtopath.c
+++ b/test/test_linkedtopath.c
@@ -31,11 +31,11 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 
 #include <config.h>
 
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include "dwarf.h"
+#include <stddef.h> /* size_t */
+#include <stdio.h>  /* printf() */
+#include <stdlib.h> /* exit() free() */
+#include <string.h> /* memset() strcmp() strlen() */
+
 #include "libdwarf.h"
 #include "libdwarf_private.h"
 #include "dwarf_base_types.h"

--- a/test/test_regex.c
+++ b/test/test_regex.c
@@ -1,5 +1,7 @@
 /*   This test code is hereby placed in the public domain. */
-#include <stdio.h>
+
+#include <stdio.h> /* printf() */
+
 #include "dd_regex.h"
 
 #define DW_DLV_NO_ENTRY -1

--- a/test/test_safe_strcpy.c
+++ b/test/test_safe_strcpy.c
@@ -4,12 +4,11 @@
   This trivial test program is hereby placed in the public domain.
 */
 
-#include "config.h"
-#include <stdio.h>
-#include <string.h>  /* strcpy() strlen() */
-#ifdef HAVE_STDDEF_H
-#include <stddef.h>
-#endif
+#include <config.h>
+
+#include <stdio.h>  /* printf() */
+#include <string.h> /* memset() strcmp() */
+
 #include "dwarf_safe_strcpy.h"
 
 static int

--- a/test/testesb.c
+++ b/test/testesb.c
@@ -31,12 +31,13 @@ Portions Copyright (C) 2013-2018 David Anderson. All Rights Reserved.
 
 */
 
-#include "config.h"
-#include <stdlib.h>
-#include <string.h>
+#include <config.h>
+
+#include <stdlib.h> /* exit() */
+#include <string.h> /* strcmp() */
+
 #include "libdwarf_private.h"
 #include "dd_esb.h"
-#define TRUE 1
 
 static int failcount = 0;
 


### PR DESCRIPTION
        modified:   test/dwarf_leb_test.c
        modified:   test/dwarf_tied_test.c
        modified:   test/getnametest.c
        modified:   test/helpertree_test.c
        modified:   test/makename_test.c
        modified:   test/section_bitmaps_test.c
        modified:   test/test_canonical.c
        modified:   test/test_dwarfstring.c
        modified:   test/test_errmsglist.c
        modified:   test/test_extra_flag_strings.c
        modified:   test/test_linkedtopath.c
        modified:   test/test_regex.c
        modified:   test/test_safe_strcpy.c
        modified:   test/testesb.c