### PR TITLE
CI msys2 autotools: pass 64 bits host and enable shared.

### DIFF
--- a/.github/workflows/ci_msys2_autotools.yml
+++ b/.github/workflows/ci_msys2_autotools.yml
@@ -25,10 +25,10 @@ jobs:
         update: true
         install: base-devel git autoconf automake libtool mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib
     - name: Configure
-        run: autoreconf -vif && ./configure --disable-static --host=x86_64-w64-mingw32
+        run: autoreconf -vif && ./configure --disable-static --enable-shared --host=x86_64-w64-mingw32
     - name: Build
       run: make -j
     - name: Check
       run: make -j check
     -name: Distcheck
-      run: make -j distcheck
+      run: make -j distcheck DISTCHECK_CONFIGURE_FLAGS="--disable-static --enable-shared --host=x86_64-w64-mingw32"


### PR DESCRIPTION
Allow distcheck to use these options too.

        modified:   .github/workflows/ci_msys2_autotools.yml