### PR TITLE
Fix undefined behavior found when compiled with UBSAN in clang.

### DIFF
--- a/src/lib/libdwarf/dwarf_line.c
+++ b/src/lib/libdwarf/dwarf_line.c
@@ -31,7 +31,9 @@
 
 #include <config.h>
 
+#ifdef HAVE_STDINT_H
 #include <stdint.h> /* uintptr_t */
+#endif /* HAVE_STDINT_H */
 #include <stdlib.h> /* free() malloc() realloc() */
 #include <string.h> /* memset() strlen() */
 
@@ -757,6 +759,7 @@ _dwarf_internal_srclines(Dwarf_Die die,
     section_end = section_start  +dbg->de_debug_line.dss_size;
     {
         Dwarf_Unsigned fission_size = 0;
+        uintptr_t line_ptr_as_uint = (uintptr_t)line_ptr;
         int resf = _dwarf_get_fission_addition_die(die, DW_SECT_LINE,
             &fission_offset,&fission_size,error);
         if (resf != DW_DLV_OK) {
@@ -766,7 +769,6 @@ _dwarf_internal_srclines(Dwarf_Die die,
 
         /* fission_offset may be 0, and adding 0 to a null pointer
            is undefined behavior with some compilers. */
-        uintptr_t line_ptr_as_uint = (uintptr_t)line_ptr;
         line_ptr_as_uint += fission_offset;
         line_ptr = (Dwarf_Small *)line_ptr_as_uint;
         if (line_ptr > section_end) {

--- a/src/lib/libdwarf/dwarf_line.c
+++ b/src/lib/libdwarf/dwarf_line.c
@@ -31,6 +31,7 @@
 
 #include <config.h>
 
+#include <stdint.h> /* uintptr_t */
 #include <stdlib.h> /* free() malloc() realloc() */
 #include <string.h> /* memset() strlen() */
 
@@ -762,7 +763,12 @@ _dwarf_internal_srclines(Dwarf_Die die,
             dwarf_dealloc(dbg, stmt_list_attr, DW_DLA_ATTR);
             return resf;
         }
-        line_ptr += fission_offset;
+
+        /* fission_offset may be 0, and adding 0 to a null pointer
+           is undefined behavior with some compilers. */
+        uintptr_t line_ptr_as_uint = (uintptr_t)line_ptr;
+        line_ptr_as_uint += fission_offset;
+        line_ptr = (Dwarf_Small *)line_ptr_as_uint;
         if (line_ptr > section_end) {
             _dwarf_error(dbg, error, DW_DLE_FISSION_ADDITION_ERROR);
             return DW_DLV_ERROR;


### PR DESCRIPTION
This patch resolves the following undefined behavior error:
"runtime error: applying zero offset to null pointer" seen when
calling dwarf_srclines_b when compiled with clang's UBSAN libraries.