### PR TITLE
Replace CMAKE dirs with PROJECT dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.3)
 project(libdwarf C CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include_directories( ${CMAKE_BINARY_DIR} )
+include_directories( ${PROJECT_BINARY_DIR} )
 
 # used to compile on MSVC upto 2013 where snprintf is not available
 macro(msvc_posix target)

--- a/src/bin/dwarfdump/CMakeLists.txt
+++ b/src/bin/dwarfdump/CMakeLists.txt
@@ -50,8 +50,8 @@ set_source_group(HEADERS "Header Files"
   ../../lib/libdwarf/libdwarf_private.h)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files"
-  ${CMAKE_SOURCE_DIR}/cmake/config.h.cmake
-  ${CMAKE_BINARY_DIR}/config.h)
+  ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake
+  ${PROJECT_BINARY_DIR}/config.h)
 	
 add_executable(dwarfdump ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 

--- a/src/bin/dwarfexample/CMakeLists.txt
+++ b/src/bin/dwarfexample/CMakeLists.txt
@@ -1,8 +1,8 @@
 set_source_group(SIMPLE_READER_SOURCES "Source Files" simplereader.c)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files"
-  ${CMAKE_SOURCE_DIR}/cmake/config.h.cmake
-  ${CMAKE_BINARY_DIR}/config.h)
+  ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake
+  ${PROJECT_BINARY_DIR}/config.h)
 
 add_executable(simplereader 
    ${SIMPLE_READER_SOURCES} 

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -14,8 +14,8 @@ set_source_group(HEADERS "Header Files" createirepfrombinary.h
     ../../lib/libdwarfp/libdwarfp.h)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files" 
-    ${CMAKE_SOURCE_DIR}/cmake/config.h.cmake
-    ${CMAKE_BINARY_DIR}/config.h)
+    ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake
+    ${PROJECT_BINARY_DIR}/config.h)
     
 add_executable(dwarfgen ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -62,8 +62,8 @@ dwarf_macho_loader.h
 dwarf_memcpy_swap.h)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files" 
-    ${CMAKE_SOURCE_DIR}/cmake/config.h.cmake 
-    ${CMAKE_BINARY_DIR}/config.h)
+    ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake 
+    ${PROJECT_BINARY_DIR}/config.h)
 	
 list(LENGTH DWARF_TARGETS targetCount)
 math(EXPR targetCount "${targetCount} - 1")

--- a/src/lib/libdwarfp/CMakeLists.txt
+++ b/src/lib/libdwarfp/CMakeLists.txt
@@ -25,8 +25,8 @@ dwarf_pro_reloc_symbolic.h
 dwarf_pro_section.h dwarf_pro_types.h dwarf_pro_util.h)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files" 
-    ${CMAKE_SOURCE_DIR}/cmake/config.h.cmake 
-    ${CMAKE_BINARY_DIR}/config.h)
+    ${PROJECT_SOURCE_DIR}/cmake/config.h.cmake 
+    ${PROJECT_BINARY_DIR}/config.h)
 
 	
 list(LENGTH DWARFP_TARGETS targetCount)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,141 +1,141 @@
 
 if (DO_TESTING)
     set_source_group(TESTSTRING "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_dwarfstring.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h)
+        ${PROJECT_SOURCE_DIR}/test/test_dwarfstring.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h)
     add_executable(selfteststring ${TESTSTRING})
     target_compile_options(selfteststring PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf")
     target_compile_options(selfteststring PRIVATE ${DW_FWALL})
     add_test(NAME selfteststring COMMAND selfteststring)
 endif()
 if (DO_TESTING)
     set_source_group(TESTEXTRASTRING "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_extra_flag_strings.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarfp/dwarf_pro_log_extra_flag_strings.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h)
+        ${PROJECT_SOURCE_DIR}/test/test_extra_flag_strings.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarfp/dwarf_pro_log_extra_flag_strings.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h)
     add_executable(selftestextrastring ${TESTEXTRASTRING})
     target_compile_options(selftestextrastring PRIVATE 
          "-DTESTING -DLIBDWARF_BUILD" )
     target_compile_options(selftestextrastring PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarfp")
     target_compile_options(selftestextrastring PRIVATE ${DW_FWALL})
     add_test(NAME selftestextrastring COMMAND selftestextrastring)
 endif()
 
 if (DO_TESTING)
     set_source_group(TESTLINKEDTOPATH "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_linkedtopath.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.h
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_debuglink.h
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_debuglink.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_error.h)
+        ${PROJECT_SOURCE_DIR}/test/test_linkedtopath.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.h
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_string.h
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_debuglink.h
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_debuglink.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_error.h)
     add_executable(selftest_linkedtopath ${TESTEXTRASTRING})
     target_compile_options(selftest_linkedtopath PRIVATE 
         "-DTESTING -DLIBDWARF_BUILD" )
     target_compile_options(selftest_linkedtopath PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarfp")
     target_compile_options(selftest_linkedtopath PRIVATE ${DW_FWALL})
     add_test(NAME selftest_linkedtopath COMMAND selftest_linkedtopath)
 endif()
 
 if (DO_TESTING)
     set_source_group(GETOPTEST_SOURCES "Source Files"
-      ${CMAKE_SOURCE_DIR}/test/test_getopt.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_getopt.h
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_getopt.c)
+      ${PROJECT_SOURCE_DIR}/test/test_getopt.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_getopt.h
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_getopt.c)
     add_executable(selfgetopttest ${GETOPTEST_SOURCES})
     target_compile_options(selfgetopttest PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarfp")
     target_compile_options(selfgetopttest PRIVATE ${DW_FWALL})
     add_test(NAME selfgetopttest COMMAND selfgetopttest)
 endif()   
 
 if (DO_TESTING)
     set_source_group(MAKENAME_SOURCES "Source Files"
-      ${CMAKE_SOURCE_DIR}/test/test_makename.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_makename.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
+      ${PROJECT_SOURCE_DIR}/test/test_makename.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_makename.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
     add_executable(selfmakename ${MAKENAME_SOURCES})
     target_compile_options(selfmakename PRIVATE ${DW_FWALL})
     target_compile_options(selfmakename PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarfp")
     target_compile_options(selfmakename PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     add_test(NAME selfmakename COMMAND selfmakename)
 endif()
 if (DO_TESTING)
     set_source_group(HELPERTREE_SOURCES "Source Files"
-      ${CMAKE_SOURCE_DIR}/test/test_helpertree.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_helpertree.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
+      ${PROJECT_SOURCE_DIR}/test/test_helpertree.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_helpertree.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
     add_executable(selfhelpertree ${HELPERTREE_SOURCES})
     target_compile_options(selfhelpertree PRIVATE ${DW_FWALL})
     target_compile_options(selfhelpertree PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/dwarfdump")
     target_compile_options(selfhelpertree PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf")
     target_compile_options(selfhelpertree PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     add_test(NAME selfhelpertree COMMAND selfhelpertree)
 endif()
 
 if (DO_TESTING)
     set_source_group(SELFMC_SOURCES "Source Files"
-      ${CMAKE_SOURCE_DIR}/test/test_macrocheck.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
-      ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
+      ${PROJECT_SOURCE_DIR}/test/test_macrocheck.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
+      ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
     add_executable(selfmacrocheck ${SELFMC_SOURCES} )
     target_compile_options(selfmacrocheck PRIVATE "-DTESTING" )
     target_compile_options(selfmacrocheck PRIVATE ${DW_FWALL})
     target_compile_options(selfmacrocheck PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarfp")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarfp")
     target_compile_options(selfmacrocheck PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     add_test(NAME selfmacrocheck COMMAND selfmacrocheck)
 endif()
 
 if (DO_TESTING)
     set_source_group(TESTESB_SOURCES "Source Files"
-       ${CMAKE_SOURCE_DIR}/test/test_esb.c
-       ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
-       ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
+       ${PROJECT_SOURCE_DIR}/test/test_esb.c
+       ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
+       ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_tsearchbal.c)
     add_executable(selftestesb ${TESTESB_SOURCES})
     target_compile_options(selftestesb PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf")
     target_compile_options(selftestesb PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     target_compile_options(selftestesb PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     target_compile_options(selftestesb PRIVATE ${DW_FWALL})
     add_test(NAME selftestesb COMMAND selftestesb)
 endif()
 if (DO_TESTING)
     set_source_group(TESTSANITIZED_SOURCES "Source Files"
-       ${CMAKE_SOURCE_DIR}/test/test_sanitized.c
-       ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
-       ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_sanitized.c)
+       ${PROJECT_SOURCE_DIR}/test/test_sanitized.c
+       ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c
+       ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_sanitized.c)
     add_executable(selftestsanitized ${TESTESB_SOURCES})
     target_compile_options(selftestsanitized PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf")
     target_compile_options(selftestsanitized PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     target_compile_options(selftestsanitized PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump")
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
     target_compile_options(selftestsanitized PRIVATE ${DW_FWALL})
     add_test(NAME selftestsanitized COMMAND selftestesb)
 endif()
@@ -143,65 +143,65 @@ endif()
 
 if (DO_TESTING)
     set_source_group(TESTLEB "Source Files" 
-        ${CMAKE_SOURCE_DIR}/test/test_dwarf_leb.c 
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_leb.c )
+        ${PROJECT_SOURCE_DIR}/test/test_dwarf_leb.c 
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_leb.c )
     add_executable(selfleb ${TESTLEB})
     target_compile_options(selfleb PRIVATE 
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf" "-DLIBDWARF_BUILD")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf" "-DLIBDWARF_BUILD")
     target_compile_options(selfleb PRIVATE ${DW_FWALL})
     add_test(NAME selfleb COMMAND selfleb)
 endif()
 
 if (DO_TESTING)
     set_source_group(TESTTIED "Source Files" 
-        ${CMAKE_SOURCE_DIR}/test/test_dwarf_tied.c 
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_tied.c 
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_tsearchhash.c )
+        ${PROJECT_SOURCE_DIR}/test/test_dwarf_tied.c 
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_tied.c 
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_tsearchhash.c )
     add_executable(selftied ${TESTTIED})
     target_compile_options(selftied PRIVATE 
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
         "-DTESTING" "-DLIBDWARF_BUILD")
     target_compile_options(selftied PRIVATE ${DW_FWALL})
     add_test(NAME selftied COMMAND selftied)
 endif()
 if (DO_TESTING) 
     set_source_group(TESTNAMES "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_getname.c
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_names.c)
+        ${PROJECT_SOURCE_DIR}/test/test_getname.c
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_names.c)
     add_executable(selftestnames ${TESTNAMES})
     target_compile_options(selftestnames PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf" "-DLIBDWARF_BUILD")
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf" "-DLIBDWARF_BUILD")
     target_compile_options(selftestnames PRIVATE ${DW_FWALL})
     add_test(NAME selftestnames COMMAND selftestnames)
 endif()
 
 if (DO_TESTING AND BUILD_DWARFEXAMPLE AND NOT WIN32)
-    set(execdl "${CMAKE_BINARY_DIR}/src/bin/dwarfexample/jitreader")
-    add_test(NAME selfjitreader COMMAND sh -c "${CMAKE_SOURCE_DIR}/test/test_jitreaderdiff.sh ${CMAKE_SOURCE_DIR}")
+    set(execdl "${PROJECT_BINARY_DIR}/src/bin/dwarfexample/jitreader")
+    add_test(NAME selfjitreader COMMAND sh -c "${PROJECT_SOURCE_DIR}/test/test_jitreaderdiff.sh ${PROJECT_SOURCE_DIR}")
 endif()
 
 if (DO_TESTING) 
     set_source_group(OBJERRMSGLIST "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_errmsglist.c 
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c)
+        ${PROJECT_SOURCE_DIR}/test/test_errmsglist.c 
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c)
     add_executable(selferrmsglist ${OBJERRMSGLIST})
     target_compile_options(selferrmsglist PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf" )
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf" )
     target_compile_options(selferrmsglist PRIVATE ${DW_FWALL})
     add_test(NAME selferrmsglist COMMAND 
-        selferrmsglist -f "${CMAKE_SOURCE_DIR}")
+        selferrmsglist -f "${PROJECT_SOURCE_DIR}")
 endif()
 
 if (DO_TESTING)
     set_source_group(CANONICALLIST "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_canonical.c 
-        ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_safe_strcpy.c
-        ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_canonical_append.c
-        ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c)
+        ${PROJECT_SOURCE_DIR}/test/test_canonical.c 
+        ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_safe_strcpy.c
+        ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_canonical_append.c
+        ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_esb.c)
     add_executable(selfcanonical ${CANONICALLIST})
     target_compile_options(selfcanonical PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf"
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf"
         "-DLIBDWARF_BUILD")
     target_compile_options(selfcanonical PRIVATE ${DW_FWALL})
     add_test(NAME selfcanonical COMMAND selfcanonical)
@@ -209,25 +209,25 @@ endif()
 
 if (DO_TESTING)
     set_source_group(SAFESTRCPYLIST "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_safe_strcpy.c 
-        ${CMAKE_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c)
+        ${PROJECT_SOURCE_DIR}/test/test_safe_strcpy.c 
+        ${PROJECT_SOURCE_DIR}/src/lib/libdwarf/dwarf_safe_strcpy.c)
     add_executable(selfteststrcpy ${SAFESTRCPYLIST})
     target_compile_options(selfteststrcpy PRIVATE
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf" )
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf" )
     target_compile_options(selfteststrcpy PRIVATE ${DW_FWALL})
     add_test(NAME selfteststrcpy COMMAND selfteststrcpy)
 endif()
 
 if (DO_TESTING)
     set_source_group(REGEXLIST "Source Files"
-        ${CMAKE_SOURCE_DIR}/test/test_regex.c 
-        ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dd_regex.c)
+        ${PROJECT_SOURCE_DIR}/test/test_regex.c 
+        ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dd_regex.c)
     add_executable(selfregex ${REGEXLIST})
     target_compile_options(selfregex PRIVATE
-        "-I$(CMAKE_BINARY_DIR)"
-        "-I${CMAKE_SOURCE_DIR}/src/bin/dwarfdump"
-        "-I${CMAKE_SOURCE_DIR}/src/lib/libdwarf" )
+        "-I$(PROJECT_BINARY_DIR)"
+        "-I${PROJECT_SOURCE_DIR}/src/bin/dwarfdump"
+        "-I${PROJECT_SOURCE_DIR}/src/lib/libdwarf" )
     target_compile_options(selfregex PRIVATE ${DW_FWALL})
     add_test(NAME selfregex COMMAND selfregex)
 endif()
@@ -235,40 +235,40 @@ endif()
 if (DO_TESTING AND NOT WIN32) 
     add_custom_target (copyconf ALL
        COMMAND ${CMAKE_COMMAND} -E
-       copy ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dwarfdump.conf
-          ${CMAKE_BINARY_DIR}/test/dwarfdump.conf )
+       copy ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dwarfdump.conf
+          ${PROJECT_BINARY_DIR}/test/dwarfdump.conf )
     add_custom_target (copyconf2 ALL
        COMMAND ${CMAKE_COMMAND} -E
-       copy ${CMAKE_SOURCE_DIR}/src/bin/dwarfdump/dwarfdump.conf
-          ${CMAKE_BINARY_DIR}/dwarfdump.conf )
-    set(pebasedir "${CMAKE_SOURCE_DIR}")
-    set(peshdir   "${CMAKE_SOURCE_DIR}/test")
-    set(pebindir  "${CMAKE_BINARY_DIR}")
+       copy ${PROJECT_SOURCE_DIR}/src/bin/dwarfdump/dwarfdump.conf
+          ${PROJECT_BINARY_DIR}/dwarfdump.conf )
+    set(pebasedir "${PROJECT_SOURCE_DIR}")
+    set(peshdir   "${PROJECT_SOURCE_DIR}/test")
+    set(pebindir  "${PROJECT_BINARY_DIR}")
     add_test(NAME selfdwarfdumppe COMMAND python3 ${peshdir}/test_dwarfdump.py PE cmake ${pebasedir} ${pebindir})
 endif()
 
 if (DO_TESTING AND NOT WIN32) 
-    set(elfbasedir "${CMAKE_SOURCE_DIR}")
-    set(elfshdir   "${CMAKE_SOURCE_DIR}/test")
-    set(elfbindir  "${CMAKE_BINARY_DIR}")
+    set(elfbasedir "${PROJECT_SOURCE_DIR}")
+    set(elfshdir   "${PROJECT_SOURCE_DIR}/test")
+    set(elfbindir  "${PROJECT_BINARY_DIR}")
     add_test(NAME selfdwarfdumpelf COMMAND python3 ${elfshdir}/test_dwarfdump.py Elf cmake ${elfbasedir} ${elfbindir})
 endif()
 
 if (DO_TESTING AND NOT WIN32) 
-    set(macbasedir "${CMAKE_SOURCE_DIR}")
-    set(macshdir   "${CMAKE_SOURCE_DIR}/test")
-    set(macbindir  "${CMAKE_BINARY_DIR}")
+    set(macbasedir "${PROJECT_SOURCE_DIR}")
+    set(macshdir   "${PROJECT_SOURCE_DIR}/test")
+    set(macbindir  "${PROJECT_BINARY_DIR}")
     add_test(NAME selfdwarfdumpmacho COMMAND python3 ${macshdir}/test_dwarfdump.py Macos cmake ${macbasedir} ${macbindir})
 endif()
 
 if (DO_TESTING AND BUILD_DWARFEXAMPLE AND NOT WIN32) 
-    set(dlbasedir "${CMAKE_SOURCE_DIR}")
-    set(dlshdir   "${CMAKE_SOURCE_DIR}/test")
+    set(dlbasedir "${PROJECT_SOURCE_DIR}")
+    set(dlshdir   "${PROJECT_SOURCE_DIR}/test")
     add_test(NAME selfdebuglinka COMMAND sh -c "${dlshdir}/test_debuglink-a.sh ${dlbasedir}")
 endif()
 
 if (DO_TESTING AND BUILD_DWARFEXAMPLE AND NOT WIN32) 
-    set(dlbasedir "${CMAKE_SOURCE_DIR}")
-    set(dlshdir   "${CMAKE_SOURCE_DIR}/test")
+    set(dlbasedir "${PROJECT_SOURCE_DIR}")
+    set(dlshdir   "${PROJECT_SOURCE_DIR}/test")
     add_test(NAME selfdebuglinkb COMMAND sh -c "${dlshdir}/test_debuglink-b.sh ${dlbasedir}")
 endif()


### PR DESCRIPTION
Replacing CMAKE_*_DIR with PROJECT_*_DIR allows adding this project as a subproject in cmake config.