### PR TITLE
CMakeLists: fix crosscompile cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,8 +225,8 @@ check_c_source_compiles("
   }" HAVE_RAW_LIBELF_OK)
 else()
 endif()
-check_c_source_runs("
   static unsigned foo( unsigned x, 
+check_c_source_compiles("
       __attribute__ ((unused)) int y)
   {  
       unsigned x2 = x + 1;


### PR DESCRIPTION
check_c_source_runs cannot be run in crosscompilation cases, only check compilation by replacing it with `check_c_source_compiles`

Fixes #149