### PR TITLE
Support for large number of section headers

### DIFF
--- a/src/lib/libdwarf/dwarf_elf_load_headers.c
+++ b/src/lib/libdwarf/dwarf_elf_load_headers.c
@@ -314,7 +314,7 @@ generic_ehdr_from_32(dwarf_elf_object_access_internals_t *ep,
         }
     }
     if (ehdr->ge_shnum >= SHN_LORESERVE ||
-        (ehdr->ge_strndx_extended && !ehdr->ge_shnum)) {
+        ehdr->ge_strndx_extended || !ehdr->ge_shnum) {
         ehdr->ge_shnum_extended = TRUE;
     } else {
         ehdr->ge_shnum_in_shnum = TRUE;
@@ -373,7 +373,7 @@ generic_ehdr_from_64(dwarf_elf_object_access_internals_t* ep,
         }
     }
     if (ehdr->ge_shnum >= SHN_LORESERVE ||
-        (ehdr->ge_strndx_extended && !ehdr->ge_shnum)) {
+        ehdr->ge_strndx_extended || !ehdr->ge_shnum) {
         ehdr->ge_shnum_extended = TRUE;
     } else {
         ehdr->ge_shnum_in_shnum = TRUE;


### PR DESCRIPTION
Hi,
`e_strndx` doesn't necessarily need to be big (`>=SHN_LORESERVE`) in tandem with big `e_shnum` (set to 0). Currently I have valid example that looks like this:
`e_shnum == 0` (where in section header at index 0, `sh_size == 100000`)
`e_strndx == 1`


Setting `e_shnum == 0` is enough to indicate that there is big number of sections. There is two quotation in ELF spec:
- https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.sheader.html

> "[...] If the **number of sections is greater than or equal to SHN_LORESERVE (0xff00), e_shnum has the value SHN_UNDEF (0)** and the actual number of section header table entries is contained in the sh_size field of the section header at index 0 (otherwise, the sh_size member of the initial entry contains 0)."

- https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html

> "e_shnum
> [...]
> If the **number of sections is greater than or equal to SHN_LORESERVE (0xff00), this member has the value zero** and the actual number of section header table entries is contained in the sh_size field of the section header at index 0. (Otherwise, the sh_size member of the initial entry contains 0.)

PS. I'm not sure, but I think that case where `e_shnum >= SHN_LORESERVE` should treated as an error, however I have not found any error check in similar project [pyelftools](https://github.com/eliben/pyelftools)
