### PR TITLE
Fix missing header files when installing libdwarf using cmake

### DIFF
--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -139,7 +139,8 @@ install(
     FILES cmake/libdwarf-config.cmake
     DESTINATION lib/cmake/libdwarf
 )
-install(DIRECTORY libdwarf DESTINATION include/
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DESTINATION include/
     FILES_MATCHING PATTERN "*.h")
 install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/libdwarf.h


### PR DESCRIPTION
In `src/lib/libdwarf/CMakeLists.txt`, the install command used to 
install the header files specified a wrong `DIRECTORY`, this patch
fixes it.

Fixes #175 