### PR TITLE
Added dwarf_get_fde_info_for_all_regs3_b

### DIFF
--- a/src/lib/libdwarf/dwarf_frame.c
+++ b/src/lib/libdwarf/dwarf_frame.c
@@ -2472,10 +2472,12 @@ _dwarf_get_fde_info_for_a_pc_row(Dwarf_Fde fde,
 }
 
 int
-dwarf_get_fde_info_for_all_regs3(Dwarf_Fde fde,
+dwarf_get_fde_info_for_all_regs3_b(Dwarf_Fde fde,
     Dwarf_Addr pc_requested,
     Dwarf_Regtable3 * reg_table,
     Dwarf_Addr * row_pc,
+    Dwarf_Bool * has_more_rows,
+    Dwarf_Addr * subsequent_pc,
     Dwarf_Error * error)
 {
 
@@ -2522,7 +2524,7 @@ dwarf_get_fde_info_for_all_regs3(Dwarf_Fde fde,
     res = _dwarf_get_fde_info_for_a_pc_row(fde, pc_requested,
         &fde_table,
         dbg->de_frame_cfa_col_number,
-        NULL,NULL,
+        has_more_rows,subsequent_pc,
         error);
     if (res != DW_DLV_OK) {
         free(reg_table_i.rt3_rules);
@@ -2585,6 +2587,19 @@ dwarf_get_fde_info_for_all_regs3(Dwarf_Fde fde,
     reg_table_i.rt3_reg_table_size = 0;
     _dwarf_free_fde_table(&fde_table);
     return DW_DLV_OK;
+}
+
+int
+dwarf_get_fde_info_for_all_regs3(Dwarf_Fde fde,
+    Dwarf_Addr pc_requested,
+    Dwarf_Regtable3 * reg_table,
+    Dwarf_Addr * row_pc,
+    Dwarf_Error * error)
+{
+    int res = dwarf_get_fde_info_for_all_regs3_b(fde,pc_requested,
+            reg_table,row_pc,NULL,NULL,error);
+
+    return res;
 }
 
 /*  Table_column DW_FRAME_CFA_COL is not meaningful.

--- a/src/lib/libdwarf/libdwarf.h
+++ b/src/lib/libdwarf/libdwarf.h
@@ -5345,6 +5345,14 @@ DW_API int dwarf_get_fde_instr_bytes(Dwarf_Fde dw_fde,
     On success returns the address of the row of
     frame data which may be a few counts off of
     the pc requested.
+    @param dw_has_more_rows
+    On success returns FALSE if there are no more rows,
+    otherwise returns TRUE.
+    @param dw_subsequent_pc
+    On success this returns the address of the next pc
+    for which there is a register row, making access
+    to all the rows in sequence much more efficient
+    than just adding 1 to a pc value.
     @param dw_error
     The usual error detail return pointer.
     @return
@@ -5352,6 +5360,23 @@ DW_API int dwarf_get_fde_instr_bytes(Dwarf_Fde dw_fde,
     FDE passed in and there is some applicable row
     in the table.
 
+*/
+DW_API int dwarf_get_fde_info_for_all_regs3_b(Dwarf_Fde dw_fde,
+    Dwarf_Addr       dw_pc_requested,
+    Dwarf_Regtable3* dw_reg_table,
+    Dwarf_Addr*      dw_row_pc,
+    Dwarf_Bool*      dw_has_more_rows,
+    Dwarf_Addr*      dw_subsequent_pc,
+    Dwarf_Error*     dw_error);
+
+/*! @brief @brief Return information on frame registers at a given pc value
+
+    Identical to dwarf_get_fde_info_for_all_regs3_b() except that
+    this doesn't output dw_has_more_rows and dw_subsequent_pc.
+
+    If you need to iterate through all rows of the FDE, consider
+    switching to dwarf_get_fde_info_for_all_regs3_b() as it is more
+    efficient.
 */
 DW_API int dwarf_get_fde_info_for_all_regs3(Dwarf_Fde dw_fde,
     Dwarf_Addr       dw_pc_requested,


### PR DESCRIPTION
In order to make it easy to iterate through all rows for a given FDE, I've added `dwarf_get_fde_info_for_all_regs3_b`.

The new function outputs the subsequent PC and whether there are more rows available, which allows for easy iteration without having to keep adding 1 to the input PC to go through all rows. This is similar to what other, existing, functions like `dwarf_get_fde_info_for_reg3_c` also do. It's a minor change that mostly just means passing on the two new output parameters verbatim  to `_dwarf_get_fde_info_for_a_pc_row` that's used internally (and already had this support).

The old `dwarf_get_fde_info_for_all_regs3` still exists, but now just calls the new function internally, so this shouldn't break anything.