### PR TITLE
handle DW_AT_data_bit_offset in get_attr_value()

### DIFF
--- a/src/bin/dwarfdump/print_die.c
+++ b/src/bin/dwarfdump/print_die.c
@@ -8187,6 +8187,7 @@ get_attr_value(Dwarf_Debug dbg, Dwarf_Half tag,
             case DW_AT_ordering:
             case DW_AT_byte_size:
             case DW_AT_bit_offset:
+            case DW_AT_data_bit_offset:
             case DW_AT_bit_size:
             case DW_AT_inline:
             case DW_AT_language:


### PR DESCRIPTION
DW_AT_data_bit_offset is not handled in get_attr_value() which cause dwarfdump output negative value of DW_AT_data_bit_offset attribute.

A simple test source code:
```c
#include <stdio.h>

struct struct_A {
        void            *p0;
        void            *p1;

        int             a: 1;
        int             b: 1;

        unsigned        c;
} a = {
        .p0 = NULL,
        .p1 = NULL,
        .a = 1,
        .b = 1,
        .c = 7,
};

int main(int argc, char *argv[])
{
        return 0;
}
```

Before patch:
```
< 2><0x00000097>      DW_TAG_member
                        DW_AT_name                  a
                        DW_AT_decl_file             0x00000001
                        DW_AT_decl_line             0x00000007
                        DW_AT_decl_column           0x00000019
                        DW_AT_type                  <0x0000005a>
                        DW_AT_bit_size              0x00000001
                        DW_AT_data_bit_offset       -128
< 2><0x000000a0>      DW_TAG_member
                        DW_AT_name                  b
                        DW_AT_decl_file             0x00000001
                        DW_AT_decl_line             0x00000008
                        DW_AT_decl_column           0x00000019
                        DW_AT_type                  <0x0000005a>
                        DW_AT_bit_size              0x00000001
                        DW_AT_data_bit_offset       -127
```

After patch:
```
< 2><0x00000097>      DW_TAG_member
                        DW_AT_name                  a
                        DW_AT_decl_file             0x00000001
                        DW_AT_decl_line             0x00000007
                        DW_AT_decl_column           0x00000019
                        DW_AT_type                  <0x0000005a>
                        DW_AT_bit_size              0x00000001
                        DW_AT_data_bit_offset       0x00000080
< 2><0x000000a0>      DW_TAG_member
                        DW_AT_name                  b
                        DW_AT_decl_file             0x00000001
                        DW_AT_decl_line             0x00000008
                        DW_AT_decl_column           0x00000019
                        DW_AT_type                  <0x0000005a>
                        DW_AT_bit_size              0x00000001
                        DW_AT_data_bit_offset       0x00000081
```