### PR TITLE
Fixed issue with project as Meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libdwarf', ['c','cpp'],
   version: '0.9.0',
   default_options : ['buildtype=debugoptimized', 'warning_level=3', 'werror=true'],
-  meson_version : '>=0.53'
+  meson_version : '>=0.56'
 )
 
 v_arr = meson.project_version().split('.')
@@ -200,7 +200,7 @@ pkgconf.set('requirements_libdwarf_libs', '')
 pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
 
 configure_file(
-  input : join_paths(meson.source_root(), 'libdwarf.pc.in'),
+  input : join_paths(meson.project_source_root(), 'libdwarf.pc.in'),
   output : 'libdwarf.pc',
   configuration : pkgconf,
   install_dir : pkg_install_dir

--- a/test/meson.build
+++ b/test/meson.build
@@ -114,7 +114,7 @@ argstests = [
   ]
 ]
 
-projectbase = meson.source_root()
+projectbase = meson.project_source_root()
 foreach atest_src : argstests
   atest_name = atest_src[0].split('.')[0]
   atexec = executable(atest_name, atest_src,
@@ -140,7 +140,7 @@ if py3_exe.found()
   foreach testscr : pyscripttests
     pytest_name = testscr[0]
     message(pytest_name)
-    buildbase = meson.build_root()
+    buildbase = meson.project_build_root()
     pyexec_name = join_paths(projectbase,'test','test_dwarfdump.py')
     test(pytest_name,py3_exe, args: [pyexec_name, pytest_name,'meson', projectbase, buildbase])
   endforeach


### PR DESCRIPTION
Replacing meson.source_root() and meson.build_root() with meson.project_source_root() and meson.project_build_root() allows adding this project as a subproject in meson config.