### PR TITLE
Remove unused and redundant checks, also fix a definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,12 +131,8 @@ endif()
 
 check_include_file( "sys/types.h"     HAVE_SYS_TYPES_H) 
 check_include_file( "sys/stat.h"      HAVE_SYS_STAT_H ) 
-check_include_file( "inttypes.h"      HAVE_INTTYPES_H   ) 
-check_include_file( "memory.h"        HAVE_MEMORY_H   ) 
-check_include_file( "strings.h"       HAVE_STRINGS_H  ) 
 check_include_file( "stdint.h"        HAVE_STDINT_H   )
 check_include_file( "unistd.h"        HAVE_UNISTD_H   )
-check_include_file( "sgidefs.h"       HAVE_SGIDEFS_H  )
 check_include_file( "stdafx.h"        HAVE_STDAFX_H   )
 check_include_file( "fcntl.h"         HAVE_FCNTL_H   ) 
 
@@ -174,7 +170,7 @@ if (HAVE_INTPTR_T)
   message(STATUS "HAVE_INTPTR_T 1: intptr_t defined in stdint.h... YES")
 else()
   message(STATUS "intptr_t defined in stdint.h... NO")
-  set(uintptr_t "long long int" )
+  set(intptr_t "long long int" )
   message(STATUS "Setting #define intptr_t " ${intptr_t})
 endif()
 if (intptr_t) 
@@ -182,31 +178,6 @@ if (intptr_t)
 else()
   message(STATUS "intptr_t value considered NO ")
 endif()
-
-
-check_c_source_compiles("
-  static unsigned foo( unsigned x, 
-      __attribute__ ((unused)) int y)
-  {  
-      unsigned x2 = x + 1;
-      return x2;
-  } 
-  
-  int main(void) {
-      unsigned y = 0;
-      y = foo(12,y);
-      return 0;
-  }"    HAVE_UNUSED_ATTRIBUTE)
-message(STATUS "Checking compiler supports __attribute__ unused... ${HAVE_UNUSED_ATTRIBUTE}")
-
-check_c_source_compiles([=[
-  #include "stdafx.h"
-  int main() 
-  { 
-      int p; p = 27;
-      return 0;
-  }]=] HAVE_STDAFX_H)
-#message(STATUS "Checking have windows stdafx.h... ${HAVE_STDAFX_H}")
 
 # Zlib and ZSTD need to be found otherwise disable it
 find_package(ZLIB)
@@ -217,15 +188,6 @@ if (ZLIB_FOUND AND ZSTD_FOUND )
   set(HAVE_ZSTD TRUE)
   set(HAVE_ZSTD_H TRUE)
 endif()
-
-check_c_source_compiles([=[
-#include <stdint.h>
-int main()
-{
-    intptr_t p; 
-    p = 27;
-    return 0;
-}]=] HAVE_INTPTR_T)
 
 message(STATUS "CMAKE_SIZEOF_VOID_P ... " ${CMAKE_SIZEOF_VOID_P} )
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -10,40 +10,23 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H 1
 
-/* Define to 1 if you have the <libelf.h> header file. */
-#cmakedefine HAVE_INTTYPES_H 1
-
 /* Define to 1 if you have the <fcntl.h> header file. */
 #cmakedefine HAVE_FCNTL_H 1
 
 /* Define to 1 if you have the <malloc.h> header file. */
 #cmakedefine HAVE_MALLOC_H 1
 
-/* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H 1
-
 /* Set to 1 if big endian . */
 #cmakedefine WORDS_BIGENDIAN 1
 
-/* Define to 1 if you have the <sgidefs.h> header file. */
-#cmakedefine HAVE_SGIDEFS_H 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H 1
-
-/* Define to 1 if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #cmakedefine HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TYPES_H 1
-
-/* Define to HAVE_UINTPTR_T 1 if the system has the type `uintptr_t'. */
-#cmakedefine HAVE_UINTPTR_T 1
-/* Define to 1 if the system has the type `intptr_t'. */
-#cmakedefine HAVE_INTPTR_T
 
 
 /*  Define to the uintptr_t to the type of an unsigned integer 
@@ -54,9 +37,6 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H 1
-
-/* Set to 1 if __attribute__ ((unused)) is available. */
-#cmakedefine HAVE_UNUSED_ATTRIBUTE 1
 
 /* Set to 1 if zlib decompression is available. */
 #cmakedefine HAVE_ZLIB 1


### PR DESCRIPTION
A handful of header checks aren't needed anymore and there are also a few redundant checks in the CMakeLists.txt. I also spotted a typo that caused `intptr_t` to not be defined after detecting that a system doesn't have it.