### PR TITLE
Add ifndef-define for O_RDONLY in elf_load_headers and generic_init

### DIFF
--- a/src/lib/libdwarf/dwarf_elf_load_headers.c
+++ b/src/lib/libdwarf/dwarf_elf_load_headers.c
@@ -87,6 +87,9 @@ calls
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif /* O_BINARY */
+#ifndef O_RDONLY
+#define O_RDONLY 0
+#endif /* O_RDONLY */
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif /* O_CLOEXEC */

--- a/src/lib/libdwarf/dwarf_generic_init.c
+++ b/src/lib/libdwarf/dwarf_generic_init.c
@@ -94,6 +94,9 @@ dwarf_init_path_dl(path true_path and globals, dbg1
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif /* O_BINARY */
+#ifndef O_RDONLY
+#define O_RDONLY 0
+#endif /* O_RDONLY */
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif /* O_CLOEXEC */

--- a/src/lib/libdwarf/dwarf_object_detector.c
+++ b/src/lib/libdwarf/dwarf_object_detector.c
@@ -62,10 +62,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif /* O_BINARY */
-
 #ifndef O_RDONLY
 #define O_RDONLY 0
-#endif
+#endif /* O_RDONLY */
 #ifndef O_CLOEXEC
 #define O_CLOEXEC 0
 #endif /* O_CLOEXEC */


### PR DESCRIPTION
This PR addresses a build failure on mingw noticed by @yannou38 in https://github.com/jeremy-rifkin/cpptrace/issues/66. On some mingw installations fcntl.h may be missing. Some files I've looked at here do `#ifndef O_RDONLY #define O_RDONLY 0` as a substitute so I've applied that to other files using O_RDONLY.