### PR TITLE
Make note of DW_AT_call_file in dwarf_srcfiles

### DIFF
--- a/src/lib/libdwarf/libdwarf.h
+++ b/src/lib/libdwarf/libdwarf.h
@@ -3326,8 +3326,8 @@ DW_API int dwarf_discr_entry_s(Dwarf_Dsc_Head dw_dsc,
     DW_DLV_OK.
 
     In referencing the array via a file-number from
-    a DW_AT_decl_file attribute one needs to
-    know if the CU is DWARF5 or not.
+    a \b DW_AT_decl_file or \b DW_AT_call_file attribute one needs
+    to know if the CU is DWARF5 or not.
 
     Line Table Version numbers match compilation unit
     version numbers except that an experimental line table
@@ -3335,11 +3335,12 @@ DW_API int dwarf_discr_entry_s(Dwarf_Dsc_Head dw_dsc,
     sometimes been used with DWARF4.
 
     For DWARF5:
-    The file-number from a \b DW_AT_decl_file
+    The file-number from a \b DW_AT_decl_file or \b DW_AT_call_file
     is the proper index into the array of string pointers.
 
     For DWARF2,3,4, including experimental line table
-    version 0xfe06 and a file-number from a \b DW_AT_decl_file:
+    version 0xfe06 and a file-number from a \b DW_AT_decl_file
+    or \b DW_AT_call_file:
     -# If the file-number is zero there is no file name to find.
     -# Otherwise subtract one(1) from the file-number and
        use the new value as the index into the array


### PR DESCRIPTION
It looks like dwarf 5 indexing behavior applies to DW_AT_call_file as well as DW_AT_decl_file, based on what I've seen in development and [llvm's](https://github.com/llvm/llvm-project/blob/3dc8ef677d7d05116a0bf6524eb38b02ca6ba042/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp#L774C45-L774C55) handling of the attribute.