### PR TITLE
override find_program/dependency in meson scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libdwarf', ['c','cpp'],
   version: '0.9.2',
   default_options : ['buildtype=debugoptimized',
   'warning_level=3', 'werror=true'],
-  meson_version : '>=0.53'
+  meson_version : '>=0.54'
 )
 
 # version 0.56 is the first version with project_source_root and

--- a/src/bin/dwarfdump/meson.build
+++ b/src/bin/dwarfdump/meson.build
@@ -60,13 +60,15 @@ if (lib_type == 'static')
   dwarfdump_args += ['-DLIBDWARF_STATIC']
 endif
 
-executable('dwarfdump', dwarfdump_src,
+dwarfdump_exe = executable('dwarfdump', dwarfdump_src,
   c_args : [ dev_cflags, libdwarf_args, dwarfdump_args ],
   link_args :  dwarf_link_args ,
   dependencies : libdwarf,
   include_directories : config_dir,
   install : true
 )
+
+meson.override_find_program('dwarfdump', dwarfdump_exe)
 
 install_data('dwarfdump.conf',
   install_dir : pkgdwarfdump

--- a/src/bin/dwarfgen/meson.build
+++ b/src/bin/dwarfgen/meson.build
@@ -15,10 +15,12 @@ endif
 
 libdwarfp_dir = include_directories('../../lib/libdwarfp')
 
-executable('dwarfgen', dwarfgen_src,
+dwarfgen_exe = executable('dwarfgen', dwarfgen_src,
   cpp_args : [ dev_cppflags, libdwarf_args,dg_args ],
   link_args :  dwarf_link_args,
   dependencies : [ libdwarf, libdwarfp ],
   include_directories : [ config_dir, libdwarfp_dir ],
   install : true
 )
+
+meson.override_find_program('dwarfgen', dwarfgen_exe)

--- a/src/lib/libdwarf/meson.build
+++ b/src/lib/libdwarf/meson.build
@@ -142,6 +142,8 @@ libdwarf = declare_dependency(
   dependencies : [zlib_deps, libzstd_deps]
 )
 
+meson.override_dependency('libdwarf', libdwarf)
+
 install_headers(libdwarf_header_src,
   install_dir : dir_pkginclude + '-' + v_maj
 )

--- a/src/lib/libdwarfp/meson.build
+++ b/src/lib/libdwarfp/meson.build
@@ -53,6 +53,8 @@ libdwarfp = declare_dependency(
   link_with : libdwarfp_lib,
 )
 
+meson.override_dependency('libdwarfp', libdwarfp)
+
 install_headers(libdwarfp_header_src,
   install_dir : dir_pkginclude + '-' + v_maj
 )


### PR DESCRIPTION
Allows use as a wrap subproject more cleanly. There is no effect by the added statements if libdwarf is not built as a subproject.
