### PR TITLE
make dwarfdump tests work under Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -196,6 +196,13 @@ if get_option('dwarfexample') == true
   subdir('src/bin/dwarfexample')
 endif
 subdir('doc')
+
+configure_file(
+  input: 'src/bin/dwarfdump/dwarfdump.conf',
+  output: 'dwarfdump.conf',
+  copy: true
+)
+
 subdir('test')
 
 # Use config_h after all subdirs have set values

--- a/test/meson.build
+++ b/test/meson.build
@@ -139,6 +139,12 @@ pyscripttests = [
 builddir = project_build_base_root
 message(['mesondebug test builds ',builddir])
 
+configure_file(
+  input: '../src/bin/dwarfdump/dwarfdump.conf',
+  output: 'dwarfdump.conf',
+  copy: true
+)
+
 py3_exe = import('python').find_installation(required:false)
 if py3_exe.found()
   foreach testscr : pyscripttests


### PR DESCRIPTION
the config file needs to be copied over. this adds that.
