### PR TITLE
Minor fixes for compatibility with MSVC.

### DIFF
--- a/src/bin/dwarfgen/createirepformfrombinary.cc
+++ b/src/bin/dwarfgen/createirepformfrombinary.cc
@@ -62,6 +62,11 @@
 #include "irepresentation.h"
 #include "createirepfrombinary.h"
 
+// Microsoft preprocessor definition that wreaks havoc
+#ifdef interface
+#undef interface
+#endif
+
 using std::string;
 using std::cout;
 using std::cerr;

--- a/src/lib/libdwarf/libdwarf_private.h
+++ b/src/lib/libdwarf/libdwarf_private.h
@@ -11,7 +11,7 @@
 #define LIBDWARF_PRIVATE_H
 #define DW_PR_XZEROS "08"
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
 #define DW_PR_DUx "I64x"
 #define DW_PR_DSx "I64x"
 #define DW_PR_DUu "I64u"


### PR DESCRIPTION
There still exist numerous warnings about conversion (C4267, C4244), but this makes it compile if /WX is off.
