### PR TITLE
Disable default werror=true in Meson manifest

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,9 @@
 project('libdwarf', ['c','cpp'],
   version: '0.9.3',
-  default_options : ['buildtype=debugoptimized',
-  'warning_level=3', 'werror=true'],
+  default_options : [
+    'buildtype=debugoptimized',
+    'warning_level=3',
+  ],
   meson_version : '>=0.54'
 )
 


### PR DESCRIPTION
Under MSVC, `/WX` (the equivalent to `-Werror`) will cause the build to crash and burn. This makes it not default to making the build crash and burn.