### PR TITLE
Specify a cmake export set

### DIFF
--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -135,5 +135,10 @@ install(EXPORT libdwarfTargets
         FILE libdwarf-targets.cmake
         NAMESPACE libdwarf::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
+export(
+  TARGETS dwarf
+  NAMESPACE libdwarf::
+  FILE "${PROJECT_BINARY_DIR}/libdwarf-targets.cmake"
+)
 install(FILES "${PROJECT_BINARY_DIR}/src/lib/libdwarf/libdwarf.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 install(FILES "${PROJECT_SOURCE_DIR}/cmake/Findzstd.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")


### PR DESCRIPTION
I got an issue on my library cpptrace about specifying an export set in cmake https://github.com/jeremy-rifkin/cpptrace/issues/189. It looks like it's important to both `install(EXPORT)` and `export()` in cmake.

In order to patch this in my repository, it looks like libdwarf needs to define an export set too. This PR implements this. Tested locally and things seem ok.