### PR TITLE
Add LIBDWARF_STATIC macro to static libdwarf dependency on meson

### DIFF
--- a/src/lib/libdwarf/meson.build
+++ b/src/lib/libdwarf/meson.build
@@ -122,8 +122,10 @@ endif
 
 if (lib_type == 'shared')
   compiler_flags = ['-DLIBDWARF_BUILD']
+  compiler_flags_public = []
 else
   compiler_flags = ['-DLIBDWARF_STATIC']
+  compiler_flags_public = ['-DLIBDWARF_STATIC']
 endif
 
 libdwarf_lib = library('dwarf', libdwarf_src,
@@ -139,6 +141,7 @@ libdwarf_lib = library('dwarf', libdwarf_src,
 libdwarf = declare_dependency(
   include_directories : [ include_directories('.')],
   link_with : libdwarf_lib,
+  compile_args : [compiler_flags_public],
   dependencies : [zlib_deps, libzstd_deps]
 )
 

--- a/src/lib/libdwarfp/meson.build
+++ b/src/lib/libdwarfp/meson.build
@@ -33,8 +33,10 @@ libdwarfp_src = [
 libdwarf_dir = include_directories('../libdwarf')
 if (lib_type == 'shared')
   compiler_flags = ['-DLIBDWARF_BUILD']
+  compiler_flags_public = []
 else
   compiler_flags = ['-DLIBDWARF_STATIC']
+  compiler_flags_public = ['-DLIBDWARF_STATIC']
 endif
 
 
@@ -50,6 +52,7 @@ libdwarfp_lib = library('dwarfp', libdwarfp_src,
 
 libdwarfp = declare_dependency(
   include_directories : [ include_directories('.')],
+  compile_args : [compiler_flags_public],
   link_with : libdwarfp_lib,
 )
 


### PR DESCRIPTION
I tried to use static build of libdwarf as a meson subproject, but it seems `LIBDWARF_STATIC` is not defined when using it and I got link errors. Adding the compile flag to `declare_dependency()` fixed the issue.