### PR TITLE
Bump cmake minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(libdwarf VERSION 0.11.2 
     DESCRIPTION "Library to access DWARF debugging information" 


### PR DESCRIPTION
Cmake is now warning about compatibility with versions `< 3.10 ` being dropped. This PR just bumps the minimum version. 

https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html#full-list suggests that 3.10 is widely available, only very old linux distros shipped older versions (like ubuntu 16 or centos 7)

Zstd recently set its minimum version to 3.10 as well https://github.com/facebook/zstd/blob/f8745da6ff1ad1e7bab384bd1f9d742439278e99/build/cmake/CMakeLists.txt#L10.

Closes #277