### PR TITLE
Suppress FIND_LIBRARY_USE_LIB64_PATHS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ endmacro()
 # view folders on supported IDEs
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-# tells cmake to look in 64bit first (cmake
-# would probably do this anyway).
-set_property(GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE)
-
 ### begin what was configure.cmake
 # cmake macros
 include(TestBigEndian)


### PR DESCRIPTION
As mentioned in the command CMake already deals with this. Worse adding this ourself could create some trouble for people using this repo with add_subdirectory or FetchContent etc...