### PR TITLE
Linking was failing during tests.  Adding link library path to CMakeList.  Link now passes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -358,3 +358,7 @@ if (DO_TESTING AND BUILD_DWARFEXAMPLE AND NOT WIN32)
     set(dlshdir   "${PROJECT_SOURCE_DIR}/test")
     add_test(NAME selfdebuglinkb COMMAND sh -c "${dlshdir}/test_debuglink-b.sh ${dlbasedir}")
 endif()
+
+if(MINGW OR MSYS OR WIN32)
+    target_link_libraries(selftest_linkedtopath PRIVATE dwarf)
+endif()


### PR DESCRIPTION
I ran the following commands:

```
mkdir build_dir;cd build_dir
cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/c/msys64/usr -DBUILD_DWARFEXAMPLE=ON -DDO_TESTING=ON -DBUILD_SHARED:BOOL=TRUE -DBUILD_NON_SHARED:BOOL=FALSE ../CMakeLists.txt

ninja
```

I received the following error:
```
[174/195] Linking C executable test\selftest_linkedtopath.exe
FAILED: test/selftest_linkedtopath.exe
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\msys64\mingw64\bin\cc.exe   test/CMakeFiles/selftest_linkedtopath.dir/test_linkedtopath.c.obj test/CMakeFiles/selftest_linkedtopath.dir/__/src/lib/libdwarf/dwarf_safe_strcpy.c.obj test/CMakeFiles/selftest_linkedtopath.dir/__/src/lib/libdwarf/dwarf_string.c.obj test/CMakeFiles/selftest_linkedtopath.dir/__/src/lib/libdwarf/dwarf_debuglink.c.obj -o test\selftest_linkedtopath.exe -Wl,--out-implib,test\libselftest_linkedtopath.dll.a -Wl,--major-image-version,0,--minor-image-version,0  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: test/CMakeFiles/selftest_linkedtopath.dir/test_linkedtopath.c.obj:test_linkedtopath.c:(.text+0xb8d): undefined reference to `__imp_dwarf_add_debuglink_global_path'
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: test/CMakeFiles/selftest_linkedtopath.dir/test_linkedtopath.c.obj:test_linkedtopath.c:(.text+0xbf7): undefined reference to `__imp_dwarf_add_debuglink_global_path'
collect2.exe: error: ld returned 1 exit status
[187/195] Linking C executable test\selfleb.exe
ninja: build stopped: subcommand failed.
```

I added the link path to the CMakeList file.
Now Ninja passes with no errors

```
 ninja
[0/1] Re-running CMake...-- Building dwarfgen    ... OFF
-- Building dwarfexample... ON
-- Building api tests   ...
-- HAVE_UINTPTR_T 1: uintptr_t defined in stdint.h... YES
-- uintptr_t value considered NO
-- HAVE_INTPTR_T 1: intptr_t defined in stdint.h... YES
-- intptr_t value considered NO
-- ENABLE_DECOMPRESSION : ON
-- Found libzstd           : TRUE
-- Found zlib              : TRUE
-- Build with zlib and zstd: TRUE
-- CMAKE_SIZEOF_VOID_P ... : 8
-- Compiler warning options... NO
-- Install prefix ... C:/msys64/usr
-- Configuring done (0.2s)
-- Generating done (0.7s)
-- Build files have been written to: C:/msys64/home/heat_/libdwarf-code_zwilcox/build_dir

ninja: no work to do.
```

[msys2cmake action now passes](https://github.com/zwilcox/libdwarf-code/actions/runs/14960605302/job/42021987713)