### PR TITLE
meson build when trying to build libdwarfp.  Updating Makefile.am

### DIFF
--- a/src/lib/libdwarfp/Makefile.am
+++ b/src/lib/libdwarfp/Makefile.am
@@ -58,6 +58,8 @@ dwarf_pro_weaks.c
 libdwarfp_la_CFLAGS = $(DWARF_CFLAGS_WARN)
 libdwarfp_la_CPPFLAGS = \
 -DLIBDWARFP_BUILD \
+-DLIBDWARF_BUILD \
+-I$(top_builddir) \
 -I$(top_srcdir)/src/lib/libdwarf
 
 libdwarfp_la_LIBADD = \


### PR DESCRIPTION
autoconf build was failing to build when trying to build `libdwarfp`


See https://github.com/davea42/libdwarf-code/issues/294 for full build log failure.

I updated [src/lib/libdwarfp/Makefile.am](https://github.com/davea42/libdwarf-code/compare/main...zwilcox:libdwarf-code:make_libdwarfp_build?expand=1#diff-09d99fe8c82fef37dd6147556e0b61497e83210fab65642c84387b136cf50404) to build dependencies.

See full build log below:

```
make -j$(nproc)
make  all-recursive
make[1]: Entering directory '/home/heat_/zbwilco-libdwarf'
Making all in src/lib/libdwarf
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/lib/libdwarf'
  CC       libdwarf_la-dwarf_abbrev.lo
  CC       libdwarf_la-dwarf_alloc.lo
  CC       libdwarf_la-dwarf_arange.lo
  CC       libdwarf_la-dwarf_crc.lo
  CC       libdwarf_la-dwarf_crc32.lo
  CC       libdwarf_la-dwarf_debugaddr.lo
  CC       libdwarf_la-dwarf_debuglink.lo
  CC       libdwarf_la-dwarf_die_deliv.lo
  CC       libdwarf_la-dwarf_debugnames.lo
  CC       libdwarf_la-dwarf_debug_sup.lo
  CC       libdwarf_la-dwarf_dsc.lo
  CC       libdwarf_la-dwarf_elf_load_headers.lo
  CC       libdwarf_la-dwarf_elfread.lo
  CC       libdwarf_la-dwarf_elf_rel_detector.lo
  CC       libdwarf_la-dwarf_error.lo
  CC       libdwarf_la-dwarf_fill_in_attr_form.lo
  CC       libdwarf_la-dwarf_find_sigref.lo
  CC       libdwarf_la-dwarf_form.lo
  CC       libdwarf_la-dwarf_fission_to_cu.lo
  CC       libdwarf_la-dwarf_form_class_names.lo
  CC       libdwarf_la-dwarf_frame.lo
  CC       libdwarf_la-dwarf_frame2.lo
  CC       libdwarf_la-dwarf_gdbindex.lo
  CC       libdwarf_la-dwarf_generic_init.lo
  CC       libdwarf_la-dwarf_global.lo
  CC       libdwarf_la-dwarf_gnu_index.lo
  CC       libdwarf_la-dwarf_groups.lo
  CC       libdwarf_la-dwarf_harmless.lo
  CC       libdwarf_la-dwarf_init_finish.lo
  CC       libdwarf_la-dwarf_leb.lo
  CC       libdwarf_la-dwarf_line.lo
  CC       libdwarf_la-dwarf_loc.lo
  CC       libdwarf_la-dwarf_locationop_read.lo
  CC       libdwarf_la-dwarf_loclists.lo
  CC       libdwarf_la-dwarf_machoread.lo
  CC       libdwarf_la-dwarf_macro.lo
  CC       libdwarf_la-dwarf_macro5.lo
  CC       libdwarf_la-dwarf_memcpy_swap.lo
  CC       libdwarf_la-dwarf_names.lo
  CC       libdwarf_la-dwarf_object_detector.lo
  CC       libdwarf_la-dwarf_object_read_common.lo
  CC       libdwarf_la-dwarf_peread.lo
  CC       libdwarf_la-dwarf_print_lines.lo
  CC       libdwarf_la-dwarf_query.lo
  CC       libdwarf_la-dwarf_safe_arithmetic.lo
  CC       libdwarf_la-dwarf_safe_strcpy.lo
  CC       libdwarf_la-dwarf_secname_ck.lo
  CC       libdwarf_la-dwarf_seekr.lo
  CC       libdwarf_la-dwarf_setup_sections.lo
  CC       libdwarf_la-dwarf_ranges.lo
  CC       libdwarf_la-dwarf_rnglists.lo
  CC       libdwarf_la-dwarf_str_offsets.lo
  CC       libdwarf_la-dwarf_string.lo
  CC       libdwarf_la-dwarf_stringsection.lo
  CC       libdwarf_la-dwarf_tied.lo
  CC       libdwarf_la-dwarf_tsearchhash.lo
  CC       libdwarf_la-dwarf_util.lo
  CC       libdwarf_la-dwarf_xu_index.lo
  CC       libdwarf_la-dwarf_local_malloc.lo
  CCLD     libdwarf.la
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/lib/libdwarf'
Making all in src/bin/dwarfdump
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/dwarfdump'
  CC       dwarfdump-dd_addrmap.o
  CC       dwarfdump-dd_attr_form.o
  CC       dwarfdump-dd_checkutil.o
  CC       dwarfdump-dd_command_options.o
  CC       dwarfdump-dd_canonical_append.o
  CC       dwarfdump-dd_common.o
  CC       dwarfdump-dd_compiler_info.o
  CC       dwarfdump-dd_regex.o
  CC       dwarfdump-dd_safe_strcpy.o
  CC       dwarfdump-dd_tsearchbal.o
  CC       dwarfdump-dwarfdump.o
  CC       dwarfdump-dd_dwconf.o
  CC       dwarfdump-dd_getopt.o
  CC       dwarfdump-dd_esb.o
  CC       dwarfdump-dd_glflags.o
  CC       dwarfdump-dd_helpertree.o
  CC       dwarfdump-dd_macrocheck.o
  CC       dwarfdump-dd_makename.o
  CC       dwarfdump-dd_naming.o
  CC       dwarfdump-dd_opscounttab.o
  CC       dwarfdump-print_abbrevs.o
  CC       dwarfdump-print_aranges.o
  CC       dwarfdump-print_debugfission.o
  CC       dwarfdump-print_die.o
  CC       dwarfdump-dd_trace_abstract_origin_etc.o
  CC       dwarfdump-print_debug_addr.o
  CC       dwarfdump-print_debug_gnu.o
  CC       dwarfdump-print_debug_names.o
  CC       dwarfdump-print_debug_sup.o
  CC       dwarfdump-print_frames.o
  CC       dwarfdump-print_gdbindex.o
  CC       dwarfdump-print_hipc_lopc_attr.o
  CC       dwarfdump-print_lines.o
  CC       dwarfdump-print_llex_codes.o
  CC       dwarfdump-print_origloclist_codes.o
  CC       dwarfdump-print_loclists.o
  CC       dwarfdump-print_loclists_codes.o
  CC       dwarfdump-print_macinfo.o
  CC       dwarfdump-print_macro.o
  CC       dwarfdump-print_pubnames.o
  CC       dwarfdump-print_ranges.o
  CC       dwarfdump-print_rnglists.o
  CC       dwarfdump-print_section_groups.o
  CC       dwarfdump-print_sections.o
  CC       dwarfdump-print_str_offsets.o
  CC       dwarfdump-print_strings.o
  CC       dwarfdump-print_tag_attributes_usage.o
  CC       dwarfdump-dd_sanitized.o
  CC       dwarfdump-dd_utf8.o
  CC       dwarfdump-dd_strstrnocase.o
  CC       dwarfdump-dd_true_section_name.o
  CC       dwarfdump-dd_uri.o
  CCLD     dwarfdump.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/dwarfdump'
Making all in src/lib/libdwarfp
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/lib/libdwarfp'
  CC       ../../../src/lib/libdwarf/libdwarfp_la-dwarf_tsearchhash.lo
  CC       ../../../src/lib/libdwarf/libdwarfp_la-dwarf_memcpy_swap.lo
  CC       ../../../src/lib/libdwarf/libdwarfp_la-dwarf_string.lo
  CC       libdwarfp_la-dwarf_pro_alloc.lo
  CC       libdwarfp_la-dwarf_pro_arange.lo
  CC       libdwarfp_la-dwarf_pro_debug_sup.lo
  CC       libdwarfp_la-dwarf_pro_die.lo
  CC       libdwarfp_la-dwarf_pro_dnames.lo
  CC       libdwarfp_la-dwarf_pro_error.lo
  CC       libdwarfp_la-dwarf_pro_expr.lo
  CC       libdwarfp_la-dwarf_pro_finish.lo
  CC       libdwarfp_la-dwarf_pro_forms.lo
  CC       libdwarfp_la-dwarf_pro_frame.lo
  CC       libdwarfp_la-dwarf_pro_funcs.lo
  CC       libdwarfp_la-dwarf_pro_init.lo
  CC       libdwarfp_la-dwarf_pro_line.lo
  CC       libdwarfp_la-dwarf_pro_log_extra_flag_strings.lo
  CC       libdwarfp_la-dwarf_pro_macinfo.lo
  CC       libdwarfp_la-dwarf_pro_pubnames.lo
  CC       libdwarfp_la-dwarf_pro_reloc.lo
  CC       libdwarfp_la-dwarf_pro_reloc_symbolic.lo
  CC       libdwarfp_la-dwarf_pro_reloc_stream.lo
  CC       libdwarfp_la-dwarf_pro_section.lo
  CC       libdwarfp_la-dwarf_pro_types.lo
  CC       libdwarfp_la-dwarf_pro_vars.lo
  CC       libdwarfp_la-dwarf_pro_weaks.lo
  CCLD     libdwarfp.la
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/lib/libdwarfp'
Making all in src/bin/dwarfgen
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/dwarfgen'
  CXX      dwarfgen-createirepformfrombinary.o
  CXX      dwarfgen-createirepfrombinary.o
  CXX      dwarfgen-irepattrtodbg.o
  CXX      dwarfgen-ireptodbg.o
  CXX      dwarfgen-dwarfgen.o
  CXX      dwarfgen-dg_getopt.o
  CXXLD    dwarfgen.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/dwarfgen'
Making all in test
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/test'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/test'
Making all in doc
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/doc'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/doc'
Making all in fuzz
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/fuzz'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/fuzz'
Making all in src/bin/gennames
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/gennames'
  CC       gennames-gennames.o
  CC       ../../../src/lib/libdwarf/gennames-dwarf_safe_strcpy.o
  CC       ../../../src/bin/dwarfdump/gennames-dd_getopt.o
  CCLD     gennames.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/gennames'
Making all in src/bin/tag_tree
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/tag_tree'
  CC       tagtree-tag_tree.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_common.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_getopt.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_tsearchbal.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_esb.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_makename.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_naming.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_glflags.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_sanitized.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_utf8.o
  CC       ../../../src/bin/dwarfdump/tagtree-dd_safe_strcpy.o
  CC       ../../../src/bin/tag_tree/tagtree-tag_common.o
  CCLD     tagtree.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/tag_tree'
Making all in src/bin/tag_attr
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/tag_attr'
  CC       tagattr-tag_attr.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_getopt.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_tsearchbal.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_common.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_esb.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_makename.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_naming.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_sanitized.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_utf8.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_glflags.o
  CC       ../../../src/bin/dwarfdump/tagattr-dd_safe_strcpy.o
  CC       ../../../src/bin/tag_tree/tagattr-tag_common.o
  CCLD     tagattr.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/tag_attr'
Making all in src/bin/attr_form
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/attr_form'
  CC       attrform-attr_form_build.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_common.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_tsearchbal.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_getopt.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_attr_form.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_esb.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_makename.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_naming.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_glflags.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_sanitized.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_utf8.o
  CC       ../../../src/bin/dwarfdump/attrform-dd_safe_strcpy.o
  CC       ../../../src/bin/tag_tree/attrform-tag_common.o
  CCLD     attrform.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/attr_form'
Making all in src/bin/buildopstab
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/buildopstab'
  CC       buildopstab-buildopscounttab.o
  CCLD     buildopstab.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/buildopstab'
Making all in src/bin/builduritable
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf/src/bin/builduritable'
  CC       builduritable-uritablebuild.o
  CCLD     builduritable.exe
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf/src/bin/builduritable'
make[2]: Entering directory '/home/heat_/zbwilco-libdwarf'
make[2]: Leaving directory '/home/heat_/zbwilco-libdwarf'
make[1]: Leaving directory '/home/heat_/zbwilco-libdwarf'
```