### PR TITLE
Compile static and shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,13 @@ option(ENABLE_DECOMPRESSION
 #  This adds compiler option -Wall (gcc compiler warnings)
 option(WALL "Add -Wall" FALSE)
 option(BUILD_DWARFDUMP "Build dwarfdump (default is YES)" TRUE)
-option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" FALSE)
+option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" TRUE)
 message(STATUS "Building dwarfgen    ... ${BUILD_DWARFGEN}")
 
-option(BUILD_DWARFEXAMPLE "Build dwarfexample (default is NO)" FALSE)
+option(BUILD_DWARFEXAMPLE "Build dwarfexample (default is NO)" TRUE)
 message(STATUS "Building dwarfexample... ${BUILD_DWARFEXAMPLE}")
 
-option(DO_TESTING "Do certain api tests (default is NO)" FALSE)
+option(DO_TESTING "Do certain api tests (default is NO)" TRUE)
 message(STATUS "Building api tests   ... ${DOTESTS}")
 ### end what was configure.cmake
 
@@ -260,40 +260,50 @@ else()
 endif()
 
 function(dwarf_common_options TARGET)
+  get_target_property(TARGET_TYPE ${TARGET} TYPE)
+  if(TARGET_TYPE STREQUAL "INTERFACE_LIBRARY")
+    set(VISIBILITY INTERFACE)
+  else()
+    set(VISIBILITY PRIVATE)
+  endif()
+
   msvc_posix(${TARGET})
-  target_compile_definitions(${TARGET} INTERFACE $<$<PLATFORM_ID:Linux>:_GNU_SOURCE>)
-  target_compile_options(${TARGET} INTERFACE
-    ${COMPILER_FLAGS}
-    $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:
-        -Wall
-        -Wextra
-        -Wno-unused-private-field
-        -Wpointer-arith
-        -Wmissing-declarations
-        -Wcomment
-        -Wformat
-        -Wpedantic
-        -Wuninitialized
-        -Wshadow
-        -Wno-long-long
-        -Werror
-    >
-    $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU,Clang,AppleClang>>:
-        -Wall
-        -Wextra
-        -Wno-unused-private-field
-        -Wpointer-arith
-        -Wmissing-declarations
-        -Wcomment
-        -Wformat
-        -Wpedantic
-        -Wuninitialized
-        -Wshadow
-        -Wno-long-long
-        -Werror
-        -Wmissing-prototypes -Wdeclaration-after-statement
-    >
-)
+
+  target_compile_definitions(${TARGET} ${VISIBILITY} $<$<PLATFORM_ID:Linux>:_GNU_SOURCE>)
+
+  target_compile_options(${TARGET} ${VISIBILITY}
+
+        $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:
+            -Wall
+            -Wextra
+            -Wno-unused-private-field
+            -Wpointer-arith
+            -Wmissing-declarations
+            -Wcomment
+            -Wformat
+            -Wpedantic
+            -Wuninitialized
+            -Wshadow
+            -Wno-long-long
+            -Werror
+        >
+
+        $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU,Clang,AppleClang>>:
+            -Wall
+            -Wextra
+            -Wpointer-arith
+            -Wmissing-declarations
+            -Wcomment
+            -Wformat
+            -Wpedantic
+            -Wuninitialized
+            -Wshadow
+            -Wno-long-long
+            -Werror
+            -Wmissing-prototypes
+            -Wdeclaration-after-statement
+        >
+    )
 endfunction()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,13 @@ option(ENABLE_DECOMPRESSION
 option(WALL "Add -Wall" FALSE)
 option(INSTALL_STATIC_LIBRARIES "Install the static libraries" FALSE)
 option(BUILD_DWARFDUMP "Build dwarfdump (default is YES)" TRUE)
-option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" TRUE)
+option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" FALSE)
 message(STATUS "Building dwarfgen    ... ${BUILD_DWARFGEN}")
 
-option(BUILD_DWARFEXAMPLE "Build dwarfexample (default is NO)" TRUE)
+option(BUILD_DWARFEXAMPLE "Build dwarfexample (default is NO)" FALSE)
 message(STATUS "Building dwarfexample... ${BUILD_DWARFEXAMPLE}")
 
-option(DO_TESTING "Do certain api tests (default is NO)" TRUE)
+option(DO_TESTING "Do certain api tests (default is NO)" FALSE)
 message(STATUS "Building api tests   ... ${DOTESTS}")
 ### end what was configure.cmake
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ project(libdwarf VERSION 2.3.3
     LANGUAGES C CXX)
 
 # libdwarf
-option(BUILD_NON_SHARED "build archive library libdwarf[p].a" TRUE)
-option(BUILD_SHARED "build shared library libdwarf[p].so and use it" FALSE)
 option(BUILD_MMAP "build library allowing mmap" TRUE)
 
 option(ENABLE_DECOMPRESSION
@@ -16,10 +14,7 @@ option(ENABLE_DECOMPRESSION
 
 #  This adds compiler option -Wall (gcc compiler warnings)
 option(WALL "Add -Wall" FALSE)
-option(LIBDWARF_STATIC "add -DLIBDWARF_STATIC" FALSE)
-
 option(BUILD_DWARFDUMP "Build dwarfdump (default is YES)" TRUE)
-
 option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" FALSE)
 message(STATUS "Building dwarfgen    ... ${BUILD_DWARFGEN}")
 
@@ -267,21 +262,8 @@ else()
   unset(DW_FWALL )
   message(STATUS "Compiler warning options... NO")
 endif()
-#if (LIBDWARF_STATIC)
-#  set(DW_LIBDWARF_STATIC -DLIBDWARF_STATIC)
-#else()
-#  unset(DW_LIBDWARF_STATIC)
-#endif()
 
 configure_file(cmake/config.h.in config.h)
-
-if(BUILD_NON_SHARED)
-  set(DW_LIBDWARF_STATIC -DLIBDWARF_STATIC)
-  set(BUILD_SHARED_LIBS NO)
-else()
-  unset(DW_LIBDWARF_STATIC)
-  set(BUILD_SHARED_LIBS YES)
-endif()
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ message(STATUS "Building api tests   ... ${DOTESTS}")
 option(PIC_ALWAYS "Build libdwarf with position-independent code for both static and shared (default is NO)" FALSE)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include_directories( ${PROJECT_BINARY_DIR} )
 
 # used to compile on MSVC upto 2013 where snprintf is not available
 macro(msvc_posix target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,15 +253,49 @@ endif ()
 
 message(STATUS "CMAKE_SIZEOF_VOID_P ... : ${CMAKE_SIZEOF_VOID_P}")
 
-#  DW_FWALLXX are gnu C++ options.
-if (WALL)
-  set(DW_FWALLXX -Wall -Wextra -Wno-unused-private-field -Wpointer-arith -Wmissing-declarations -Wcomment -Wformat -Wpedantic -Wuninitialized -Wshadow -Wno-long-long -Werror)
-  set(DW_FWALL ${DW_FWALLXX} -Wpointer-arith -Wmissing-declarations -Wmissing-prototypes -Wdeclaration-after-statement -Wextra -Wcomment -Wformat -Wpedantic -Wuninitialized -Wno-long-long -Wshadow -Werror )
-  message(STATUS "Compiler warning options... YES ${DW_FWALL}")
+if(WALL)
+  message(STATUS "Compiler warning options... YES")
 else()
-  unset(DW_FWALL )
   message(STATUS "Compiler warning options... NO")
 endif()
+
+function(dwarf_common_options TARGET)
+  msvc_posix(${TARGET})
+  target_compile_definitions(${TARGET} INTERFACE $<$<PLATFORM_ID:Linux>:_GNU_SOURCE>)
+  target_compile_options(${TARGET} INTERFACE
+    ${COMPILER_FLAGS}
+    $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:
+        -Wall
+        -Wextra
+        -Wno-unused-private-field
+        -Wpointer-arith
+        -Wmissing-declarations
+        -Wcomment
+        -Wformat
+        -Wpedantic
+        -Wuninitialized
+        -Wshadow
+        -Wno-long-long
+        -Werror
+    >
+    $<$<AND:$<BOOL:${WALL}>,$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU,Clang,AppleClang>>:
+        -Wall
+        -Wextra
+        -Wno-unused-private-field
+        -Wpointer-arith
+        -Wmissing-declarations
+        -Wcomment
+        -Wformat
+        -Wpedantic
+        -Wuninitialized
+        -Wshadow
+        -Wno-long-long
+        -Werror
+        -Wmissing-prototypes -Wdeclaration-after-statement
+    >
+)
+endfunction()
+
 
 configure_file(cmake/config.h.in config.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(libdwarf VERSION 2.3.3 
     DESCRIPTION "Library to access DWARF debugging information" 
     HOMEPAGE_URL "https://github.com/davea42/libdwarf-code.git"
-    LANGUAGES C CXX)
+    LANGUAGES C)
 
 # libdwarf
 option(BUILD_MMAP "build library allowing mmap" TRUE)
@@ -17,7 +17,17 @@ option(WALL "Add -Wall" FALSE)
 option(INSTALL_STATIC_LIBRARIES "Install the static libraries" FALSE)
 option(BUILD_DWARFDUMP "Build dwarfdump (default is YES)" TRUE)
 option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" FALSE)
-message(STATUS "Building dwarfgen    ... ${BUILD_DWARFGEN}")
+if(BUILD_DWARFGEN)
+  include(CheckLanguage)
+  check_language(CXX)
+  if(CMAKE_CXX_COMPILER)
+    enable_language(CXX)
+  else()
+    message(STATUS "No C++ compiler available; disabling dwarfgen")
+    set(BUILD_DWARFGEN OFF CACHE BOOL "Build dwarfgen" FORCE)
+  endif()
+  message(STATUS "Building dwarfgen ... ${BUILD_DWARFGEN}")
+endif()
 
 option(BUILD_DWARFEXAMPLE "Build dwarfexample (default is NO)" FALSE)
 message(STATUS "Building dwarfexample... ${BUILD_DWARFEXAMPLE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ENABLE_DECOMPRESSION
 
 #  This adds compiler option -Wall (gcc compiler warnings)
 option(WALL "Add -Wall" FALSE)
+option(INSTALL_STATIC_LIBRARIES "Install the static libraries" FALSE)
 option(BUILD_DWARFDUMP "Build dwarfdump (default is YES)" TRUE)
 option(BUILD_DWARFGEN "Build dwarfgen (default is NO)" TRUE)
 message(STATUS "Building dwarfgen    ... ${BUILD_DWARFGEN}")

--- a/src/bin/dwarfdump/CMakeLists.txt
+++ b/src/bin/dwarfdump/CMakeLists.txt
@@ -71,7 +71,7 @@ target_compile_definitions(dwarfdump PRIVATE
     _GNU_SOURCE)
 target_compile_options(dwarfdump PRIVATE ${DW_FWALL})
 
-target_link_libraries(dwarfdump PRIVATE dwarf)
+target_link_libraries(dwarfdump PRIVATE dwarf-static)
 
 install(TARGETS dwarfdump DESTINATION
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/bin/dwarfdump/CMakeLists.txt
+++ b/src/bin/dwarfdump/CMakeLists.txt
@@ -1,62 +1,101 @@
 
-set_source_group(SOURCES "Source Files" dd_addrmap.c
-    dd_all_srcfiles.c
-    dd_checkutil.c dd_common.c dd_regex.c dd_safe_strcpy.c
-    dwarfdump.c dd_dwconf.c dd_helpertree.c
-    dd_glflags.c dd_command_options.c dd_compiler_info.c
-    dd_macrocheck.c
-    dd_opscounttab.c
-    print_abbrevs.c print_aranges.c
-    dd_attr_form.c
-    dd_canonical_append.c
-    dd_check_attr_encoding.c
-    dd_lvn_table.c
-    print_debugfission.c print_die.c
-    dd_trace_abstract_origin_etc.c
-    print_debug_addr.c
-    print_debug_gnu.c
-    print_debug_names.c  print_debug_sup.c
-    print_frames.c  print_gdbindex.c
-    print_hipc_lopc_attr.c
-    print_lines.c
-    print_llex_codes.c print_origloclist_codes.c
-    print_loclists_codes.c
-    print_loclists.c
-    print_macro.c print_macinfo.c
-    print_pubnames.c print_ranges.c
-    print_rnglists.c
-    print_str_offsets.c
-    print_sections.c  print_section_groups.c
-    print_strings.c
-    print_tag_attributes_usage.c
-    dd_sanitized.c dd_strstrnocase.c
-    dd_true_section_name.c dd_uri.c dd_utf8.c
-    dd_getopt.c dd_makename.c
-    dd_naming.c dd_esb.c dd_tsearchbal.c)
+set_source_group(SOURCES "Source Files"
+dd_addrmap.c
+dd_all_srcfiles.c
+dd_checkutil.c
+dd_common.c
+dd_regex.c
+dd_safe_strcpy.c
+dwarfdump.c
+dd_dwconf.c
+dd_helpertree.c
+dd_glflags.c
+dd_command_options.c
+dd_compiler_info.c
+dd_macrocheck.c
+dd_opscounttab.c
+print_abbrevs.c
+print_aranges.c
+dd_attr_form.c
+dd_canonical_append.c
+dd_check_attr_encoding.c
+dd_lvn_table.c
+print_debugfission.c
+print_die.c
+dd_trace_abstract_origin_etc.c
+print_debug_addr.c
+print_debug_gnu.c
+print_debug_names.c
+print_debug_sup.c
+print_frames.c
+print_gdbindex.c
+print_hipc_lopc_attr.c
+print_lines.c
+print_llex_codes.c
+print_origloclist_codes.c
+print_loclists_codes.c
+print_loclists.c
+print_macro.c
+print_macinfo.c
+print_pubnames.c
+print_ranges.c
+print_rnglists.c
+print_str_offsets.c
+print_sections.c
+print_section_groups.c
+print_strings.c
+print_tag_attributes_usage.c
+dd_sanitized.c
+dd_strstrnocase.c
+dd_true_section_name.c
+dd_uri.c
+dd_utf8.c
+dd_getopt.c
+dd_makename.c
+dd_naming.c
+dd_esb.c
+dd_tsearchbal.c)
 	
 set_source_group(HEADERS "Header Files"
-  dd_addrmap.h dd_all_srcfiles.h
-  dd_attr_form.h dd_checkutil.h dd_common.h dd_regex.h
-  dd_safe_strcpy.h dd_dwconf.h
-  dd_minimal.h
-  dd_command_options.h dd_compiler_info.h
-  dd_opscounttab.h
-  print_debug_gnu.h
-  dd_dwconf_using_functions.h dd_esb_using_functions.h
-  dd_elf_cputype.h
-  dd_pe_cputype.h
-  dd_helpertree.h
-  dd_canonical_append.h
-  dwarfdump-af-table-ext.h dwarfdump-af-table-std.h
-  dwarfdump-ta-ext-table.h dwarfdump-ta-table.h
-  dwarfdump-tt-ext-table.h dwarfdump-tt-table.h
-  dd_getopt.h dd_esb.h dd_glflags.h dd_globals.h
-  dd_mac_cputype.h
-  dd_macrocheck.h dd_defined_types.h
-  dd_sanitized.h
-  dd_naming.h dd_makename.h dd_tsearchbal.h print_frames.h
-  dd_uri.h dd_utf8.h
-  ../../lib/libdwarf/libdwarf_private.h)
+dd_addrmap.h
+dd_all_srcfiles.h
+dd_attr_form.h
+dd_checkutil.h
+dd_common.h
+dd_regex.h
+dd_safe_strcpy.h
+dd_dwconf.h
+dd_minimal.h
+dd_command_options.h
+dd_compiler_info.h
+dd_opscounttab.h
+print_debug_gnu.h
+dd_dwconf_using_functions.h
+dd_esb_using_functions.h
+dd_elf_cputype.h
+dd_pe_cputype.h
+dd_helpertree.h
+dd_canonical_append.h
+dwarfdump-af-table-ext.h
+dwarfdump-af-table-std.h
+dwarfdump-ta-ext-table.h
+dwarfdump-ta-table.h
+dwarfdump-tt-ext-table.h
+dwarfdump-tt-table.h
+dd_getopt.h
+dd_esb.h
+dd_glflags.h
+dd_globals.h
+dd_mac_cputype.h
+dd_macrocheck.h
+dd_defined_types.h
+dd_sanitized.h
+dd_naming.h
+dd_makename.h
+dd_tsearchbal.h
+print_frames.h
+dd_uri.h dd_utf8.h
+)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files"
   ${PROJECT_SOURCE_DIR}/cmake/config.h.in
@@ -66,9 +105,7 @@ add_executable(dwarfdump ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 dwarf_common_options(dwarfdump)
 set_folder(dwarfdump src/bin/dwarfdump)
 
-target_compile_definitions(dwarfdump PRIVATE
-    "CONFPREFIX=${CMAKE_INSTALL_PREFIX}/lib" ${DW_LIBDWARF_STATIC}
-    _GNU_SOURCE)
+target_compile_definitions(dwarfdump PRIVATE "CONFPREFIX=${CMAKE_INSTALL_PREFIX}/lib")
 
 target_link_libraries(dwarfdump PRIVATE dwarf-static)
 

--- a/src/bin/dwarfdump/CMakeLists.txt
+++ b/src/bin/dwarfdump/CMakeLists.txt
@@ -96,12 +96,8 @@ dd_tsearchbal.h
 print_frames.h
 dd_uri.h dd_utf8.h
 )
-
-set_source_group(CONFIGURATION_FILES "Configuration Files"
-  ${PROJECT_SOURCE_DIR}/cmake/config.h.in
-  ${PROJECT_BINARY_DIR}/config.h)
 	
-add_executable(dwarfdump ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+add_executable(dwarfdump ${SOURCES} ${HEADERS})
 dwarf_common_options(dwarfdump)
 set_folder(dwarfdump src/bin/dwarfdump)
 

--- a/src/bin/dwarfdump/CMakeLists.txt
+++ b/src/bin/dwarfdump/CMakeLists.txt
@@ -63,13 +63,12 @@ set_source_group(CONFIGURATION_FILES "Configuration Files"
   ${PROJECT_BINARY_DIR}/config.h)
 	
 add_executable(dwarfdump ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
-
+dwarf_common_options(dwarfdump)
 set_folder(dwarfdump src/bin/dwarfdump)
 
 target_compile_definitions(dwarfdump PRIVATE
     "CONFPREFIX=${CMAKE_INSTALL_PREFIX}/lib" ${DW_LIBDWARF_STATIC}
     _GNU_SOURCE)
-target_compile_options(dwarfdump PRIVATE ${DW_FWALL})
 
 target_link_libraries(dwarfdump PRIVATE dwarf-static)
 

--- a/src/bin/dwarfexample/CMakeLists.txt
+++ b/src/bin/dwarfexample/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_library(dwarf_example INTERFACE)
 dwarf_common_options(dwarf_example)
-target_compile_definitions(dwarf_example INTERFACE CONFPREFIX={CMAKE_INSTALL_PREFIX}/lib ${DW_LIBDWARF_STATIC})
+target_compile_definitions(dwarf_example INTERFACE CONFPREFIX={CMAKE_INSTALL_PREFIX}/lib)
 target_link_libraries(dwarf_example INTERFACE dwarf-shared)
 
 add_executable(simplereader simplereader.c)

--- a/src/bin/dwarfexample/CMakeLists.txt
+++ b/src/bin/dwarfexample/CMakeLists.txt
@@ -1,8 +1,8 @@
 
 add_library(dwarf_example INTERFACE)
-target_compile_definitions(dwarf_example INTERFACE CONFPREFIX={CMAKE_INSTALL_PREFIX}/lib ${DW_LIBDWARF_STATIC} _GNU_SOURCE)
-target_compile_options(dwarf_example INTERFACE ${DW_FWALL})
-target_link_libraries(dwarf_example INTERFACE dwarf)
+dwarf_common_options(dwarf_example)
+target_compile_definitions(dwarf_example INTERFACE CONFPREFIX={CMAKE_INSTALL_PREFIX}/lib ${DW_LIBDWARF_STATIC})
+target_link_libraries(dwarf_example INTERFACE dwarf-shared)
 
 add_executable(simplereader simplereader.c)
 set_folder(simplereader src/bin/dwarfexample)

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -1,17 +1,26 @@
-set_source_group(SOURCES "Source Files" createirepformfrombinary.cc
-    createirepfrombinary.cc
-    dwarfgen.cc irepattrtodbg.cc ireptodbg.cc
-    dg_getopt.cc)
+set_source_group(SOURCES "Source Files"
+createirepformfrombinary.cc
+createirepfrombinary.cc
+dwarfgen.cc
+irepattrtodbg.cc
+ireptodbg.cc
+dg_getopt.cc)
 
-set_source_group(HEADERS "Header Files" createirepfrombinary.h
-    general.h irepattrtodbg.h
-    irepdie.h irepform.h irepframe.h
-    irepline.h irepmacro.h ireppubnames.h
-    irepresentation.h ireptodbg.h strtabdata.h
-    ../../lib/libdwarf/libdwarf_private.h
-    dg_getopt.h
-    ../../lib/libdwarf/dwarf.h
-    ../../lib/libdwarfp/libdwarfp.h)
+set_source_group(HEADERS "Header Files"
+createirepfrombinary.h
+general.h
+irepattrtodbg.h
+irepdie.h
+irepform.h
+irepframe.h
+irepline.h
+irepmacro.h
+ireppubnames.h
+irepresentation.h
+ireptodbg.h
+strtabdata.h
+dg_getopt.h
+)
 
 set_source_group(CONFIGURATION_FILES "Configuration Files"
     ${PROJECT_SOURCE_DIR}/cmake/config.h.in

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -21,13 +21,11 @@ add_executable(dwarfgen ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 
 set_folder(dwarfgen src/bin/dwarfgen)
 dwarf_common_options(dwarfgen)
-target_compile_definitions(dwarfgen PRIVATE ${DW_LIBDWARF_STATIC})
-message("Current cmake src dir ${CMAKE_CURRENT_SOURCE_DIR}")
-target_include_directories(dwarfgen PRIVATE
-   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarf
-   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarfp)
+#target_include_directories(dwarfgen PRIVATE
+#   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarf
+#   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarfp)
 
-target_link_libraries(dwarfgen PRIVATE dwarfp dwarf-static)
+target_link_libraries(dwarfgen PRIVATE dwarfp-static dwarf-static)
 
 install(TARGETS dwarfgen DESTINATION
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -20,8 +20,7 @@ set_source_group(CONFIGURATION_FILES "Configuration Files"
 add_executable(dwarfgen ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 
 set_folder(dwarfgen src/bin/dwarfgen)
-
-target_compile_options(dwarfgen PRIVATE ${DW_FWALLXX})
+dwarf_common_options(dwarfgen)
 target_compile_definitions(dwarfgen PRIVATE ${DW_LIBDWARF_STATIC})
 message("Current cmake src dir ${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(dwarfgen PRIVATE

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -22,11 +22,7 @@ strtabdata.h
 dg_getopt.h
 )
 
-set_source_group(CONFIGURATION_FILES "Configuration Files"
-    ${PROJECT_SOURCE_DIR}/cmake/config.h.in
-    ${PROJECT_BINARY_DIR}/config.h)
-
-add_executable(dwarfgen ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+add_executable(dwarfgen ${SOURCES} ${HEADERS})
 
 set_folder(dwarfgen src/bin/dwarfgen)
 dwarf_common_options(dwarfgen)

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -21,9 +21,6 @@ add_executable(dwarfgen ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
 
 set_folder(dwarfgen src/bin/dwarfgen)
 dwarf_common_options(dwarfgen)
-#target_include_directories(dwarfgen PRIVATE
-#   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarf
-#   ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarfp)
 
 target_link_libraries(dwarfgen PRIVATE dwarfp-static dwarf-static)
 

--- a/src/bin/dwarfgen/CMakeLists.txt
+++ b/src/bin/dwarfgen/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(dwarfgen PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarf
    ${CMAKE_CURRENT_SOURCE_DIR}/../../lib/libdwarfp)
 
-target_link_libraries(dwarfgen PRIVATE dwarfp dwarf)
+target_link_libraries(dwarfgen PRIVATE dwarfp dwarf-static)
 
 install(TARGETS dwarfgen DESTINATION
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -136,7 +136,7 @@ set_target_properties(dwarf-shared PROPERTIES
                                    VERSION "${PROJECT_VERSION}"
                                    SOVERSION "${PROJECT_VERSION_MAJOR}")
 target_compile_definitions(dwarf-shared PRIVATE LIBDWARF_BUILD PUBLIC PIC)
-target_link_libraries(dwarf-shared PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
+target_link_libraries(dwarf-shared PRIVATE $<$<AND:$<BOOL:${ZLIB_FOUND}>,$<BOOL:${zstd_FOUND}>>:ZLIB::ZLIB;${ZSTD_LIB}>)
 target_include_directories(dwarf-shared PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
@@ -157,7 +157,7 @@ set_target_properties(dwarf-static PROPERTIES
                                    EXPORT_NAME "dwarf-static"
                                    PUBLIC_HEADER "libdwarf.h;dwarf.h")
 target_compile_definitions(dwarf-static PUBLIC LIBDWARF_STATIC $<$<BOOL:${PIC_ALWAYS}>:PIC>)
-target_link_libraries(dwarf-static PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
+target_link_libraries(dwarf-static PRIVATE $<$<AND:$<BOOL:${ZLIB_FOUND}>,$<BOOL:${zstd_FOUND}>>:ZLIB::ZLIB;${ZSTD_LIB}>)
 target_include_directories(dwarf-static PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -175,7 +175,13 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(${PROJECT_SOURCE_DIR}/src/lib/libdwarf/cmake/libdwarfConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" VERSION "${PROJECT_VERSION}" COMPATIBILITY SameMinorVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
-install(TARGETS dwarf-shared dwarf-static EXPORT libdwarfTargets
+
+if(INSTALL_STATIC_LIBRARIES)
+  set(DWARF_STATIC_LIB "dwarf-static")
+endif()
+
+install(TARGETS dwarf-shared ${DWARF_STATIC_LIB}
+        EXPORT libdwarfTargets
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
@@ -184,7 +190,7 @@ install(EXPORT libdwarfTargets
         NAMESPACE libdwarf::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 export(
-  TARGETS dwarf-shared dwarf-static
+  TARGETS dwarf-shared ${DWARF_STATIC_LIB}
   NAMESPACE libdwarf::
   FILE "${CMAKE_CURRENT_BINARY_DIR}/libdwarf-targets.cmake"
 )

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -135,7 +135,7 @@ set_target_properties(dwarf-shared PROPERTIES
                                    PUBLIC_HEADER "libdwarf.h;dwarf.h"
                                    VERSION "${PROJECT_VERSION}"
                                    SOVERSION "${PROJECT_VERSION_MAJOR}")
-target_compile_definitions(dwarf-shared PUBLIC LIBDWARF_BUILD PIC)
+target_compile_definitions(dwarf-shared PRIVATE LIBDWARF_BUILD PUBLIC PIC)
 target_link_libraries(dwarf-shared PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
 target_include_directories(dwarf-shared PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -117,16 +117,6 @@ set_source_group(CONFIGURATION_FILES "Configuration Files"
   "${PROJECT_SOURCE_DIR}/cmake/config.h.in"
   "${PROJECT_BINARY_DIR}/config.h")
 
-
-# All the things common to shared and static builds
-add_library(dwarf-common INTERFACE)
-set_folder(dwarf-common src/lib/libdwarf)
-msvc_posix(dwarf-common)
-if(ZLIB_FOUND AND zstd_FOUND)
-  target_link_libraries(dwarf-common INTERFACE ZLIB::ZLIB ${ZSTD_LIB} )
-endif()
-target_compile_options(dwarf-common INTERFACE ${COMPILER_FLAGS} ${DW_FWALL})
-target_compile_definitions(dwarf-common INTERFACE $<$<PLATFORM_ID:Linux>:_GNU_SOURCE>)
 # The -DPIC is so we find the right DW_API value in libdwarf.h with cmake with Linux.
 # Dwarfgen requires all symbols in .so to be visible, so do not say hidden on libdwarf in that case.
 
@@ -135,6 +125,8 @@ add_library(dwarf-shared SHARED
             ${SOURCES}
             ${HEADERS}
             ${CONFIGURATION_FILES})
+set_folder(dwarf-shared src/lib/libdwarf)
+dwarf_common_options(dwarf-shared)
 set_target_properties(dwarf-shared PROPERTIES 
                                    C_VISIBILITY_PRESET hidden
                                    VISIBILITY_INLINES_HIDDEN TRUE
@@ -144,7 +136,7 @@ set_target_properties(dwarf-shared PROPERTIES
                                    VERSION "${PROJECT_VERSION}"
                                    SOVERSION "${PROJECT_VERSION_MAJOR}")
 target_compile_definitions(dwarf-shared PUBLIC LIBDWARF_BUILD PIC)
-target_link_libraries(dwarf-shared PRIVATE dwarf-common)
+target_link_libraries(dwarf-shared PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
 target_include_directories(dwarf-shared PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -156,13 +148,15 @@ add_library(dwarf-static STATIC
             ${SOURCES}
             ${HEADERS}
             ${CONFIGURATION_FILES})
+set_folder(dwarf-static src/lib/libdwarf)
+dwarf_common_options(dwarf-static)
 set_target_properties(dwarf-static PROPERTIES 
                                    POSITION_INDEPENDENT_CODE $<$<BOOL:${PIC_ALWAYS}>:ON>
                                    OUTPUT_NAME "$<$<PLATFORM_ID:Windows>:dwarf-static>$<$<NOT:$<PLATFORM_ID:Windows>>:dwarf>"
                                    EXPORT_NAME "dwarf-static"
                                    PUBLIC_HEADER "libdwarf.h;dwarf.h")
 target_compile_definitions(dwarf-static PUBLIC LIBDWARF_STATIC $<$<BOOL:${PIC_ALWAYS}>:PIC>)
-target_link_libraries(dwarf-static PRIVATE dwarf-common)
+target_link_libraries(dwarf-static PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
 target_include_directories(dwarf-static PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -179,7 +173,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(${PROJECT_SOURCE_DIR}/src/lib/libdwarf/cmake/libdwarfConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" VERSION "${PROJECT_VERSION}" COMPATIBILITY SameMinorVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
-install(TARGETS dwarf-common dwarf-shared dwarf-static EXPORT libdwarfTargets
+install(TARGETS dwarf-shared dwarf-static EXPORT libdwarfTargets
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
@@ -188,7 +182,7 @@ install(EXPORT libdwarfTargets
         NAMESPACE libdwarf::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 export(
-  TARGETS dwarf-common dwarf-shared dwarf-static
+  TARGETS dwarf-shared dwarf-static
   NAMESPACE libdwarf::
   FILE "${CMAKE_CURRENT_BINARY_DIR}/libdwarf-targets.cmake"
 )

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -117,51 +117,57 @@ set_source_group(CONFIGURATION_FILES "Configuration Files"
   "${PROJECT_SOURCE_DIR}/cmake/config.h.in"
   "${PROJECT_BINARY_DIR}/config.h")
 
-# The -DPIC is so we find the right DW_API value in libdwarf.h
-# with cmake with Linux.
-# Dwarfgen requires all symbols in .so to be visible, so
-# do not say hidden on libdwarf in that case.
-if (BUILD_SHARED)
-    if(NOT BUILD_DWARFGEN)
-      set(CMAKE_C_VISIBILITY_PRESET hidden)
-    endif()
-    set(DEFS LIBDWARF_BUILD PIC)
-else()
-    set(DEFS LIBDWARF_STATIC)
-endif()
 
-if (PIC_ALWAYS)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-  list(APPEND DEFS PIC)
+# All the things common to shared and static builds
+add_library(dwarf-common INTERFACE)
+set_folder(dwarf-common src/lib/libdwarf)
+msvc_posix(dwarf-common)
+if(ZLIB_FOUND AND zstd_FOUND)
+  target_link_libraries(dwarf-common INTERFACE ZLIB::ZLIB ${ZSTD_LIB} )
 endif()
+target_compile_options(dwarf-common INTERFACE ${COMPILER_FLAGS} ${DW_FWALL})
+target_compile_definitions(dwarf-common INTERFACE $<$<PLATFORM_ID:Linux>:_GNU_SOURCE>)
+# The -DPIC is so we find the right DW_API value in libdwarf.h with cmake with Linux.
+# Dwarfgen requires all symbols in .so to be visible, so do not say hidden on libdwarf in that case.
 
-if(BUILD_SHARED)
-    add_library(dwarf SHARED ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
-    add_library(libdwarf::dwarf-shared ALIAS dwarf)
-else()
-    add_library(dwarf STATIC ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
-    add_library(libdwarf::dwarf-static ALIAS dwarf)
-endif()
-set_folder(dwarf src/lib/libdwarf)
-target_compile_options(dwarf PRIVATE ${COMPILER_FLAGS} ${DW_FWALL}
-    -D_GNU_SOURCE)
-msvc_posix(dwarf)
-target_compile_definitions(dwarf PUBLIC ${DEFS})
-target_include_directories(dwarf PUBLIC
+# shared one :
+add_library(dwarf-shared SHARED 
+            ${SOURCES}
+            ${HEADERS}
+            ${CONFIGURATION_FILES})
+set_target_properties(dwarf-shared PROPERTIES 
+                                   C_VISIBILITY_PRESET hidden
+                                   VISIBILITY_INLINES_HIDDEN TRUE
+                                   OUTPUT_NAME "dwarf"
+                                   EXPORT_NAME "dwarf"
+                                   PUBLIC_HEADER "libdwarf.h;dwarf.h"
+                                   VERSION "${PROJECT_VERSION}"
+                                   SOVERSION "${PROJECT_VERSION_MAJOR}")
+target_compile_definitions(dwarf-shared PUBLIC LIBDWARF_BUILD PIC)
+target_link_libraries(dwarf-shared PRIVATE dwarf-common)
+target_include_directories(dwarf-shared PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
-if(ZLIB_FOUND AND zstd_FOUND)
-  target_link_libraries(dwarf PRIVATE  ZLIB::ZLIB ${ZSTD_LIB} )
-endif()
-set_target_properties(dwarf PROPERTIES PUBLIC_HEADER "libdwarf.h;dwarf.h")
-set_target_properties(dwarf PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}")
-install(TARGETS dwarf
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        )
+add_library(libdwarf::dwarf ALIAS dwarf-shared)
+
+# static one :
+add_library(dwarf-static STATIC
+            ${SOURCES}
+            ${HEADERS}
+            ${CONFIGURATION_FILES})
+set_target_properties(dwarf-static PROPERTIES 
+                                   POSITION_INDEPENDENT_CODE $<$<BOOL:${PIC_ALWAYS}>:ON>
+                                   OUTPUT_NAME "$<$<PLATFORM_ID:Windows>:dwarf-static>$<$<NOT:$<PLATFORM_ID:Windows>>:dwarf>"
+                                   EXPORT_NAME "dwarf-static"
+                                   PUBLIC_HEADER "libdwarf.h;dwarf.h")
+target_compile_definitions(dwarf-static PUBLIC LIBDWARF_STATIC $<$<BOOL:${PIC_ALWAYS}>:PIC>)
+target_link_libraries(dwarf-static PRIVATE dwarf-common)
+target_include_directories(dwarf-static PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+add_library(libdwarf::dwarf-static ALIAS dwarf-static)
 
 configure_file(libdwarf.pc.in libdwarf.pc @ONLY)
 
@@ -173,7 +179,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(${PROJECT_SOURCE_DIR}/src/lib/libdwarf/cmake/libdwarfConfig.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" VERSION "${PROJECT_VERSION}" COMPATIBILITY SameMinorVersion)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/libdwarfConfigVersion.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
-install(TARGETS dwarf EXPORT libdwarfTargets
+install(TARGETS dwarf-common dwarf-shared dwarf-static EXPORT libdwarfTargets
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
@@ -182,7 +188,7 @@ install(EXPORT libdwarfTargets
         NAMESPACE libdwarf::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarf")
 export(
-  TARGETS dwarf
+  TARGETS dwarf-common dwarf-shared dwarf-static
   NAMESPACE libdwarf::
   FILE "${CMAKE_CURRENT_BINARY_DIR}/libdwarf-targets.cmake"
 )

--- a/src/lib/libdwarf/CMakeLists.txt
+++ b/src/lib/libdwarf/CMakeLists.txt
@@ -139,6 +139,7 @@ target_compile_definitions(dwarf-shared PRIVATE LIBDWARF_BUILD PUBLIC PIC)
 target_link_libraries(dwarf-shared PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
 target_include_directories(dwarf-shared PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
 add_library(libdwarf::dwarf ALIAS dwarf-shared)
@@ -159,6 +160,7 @@ target_compile_definitions(dwarf-static PUBLIC LIBDWARF_STATIC $<$<BOOL:${PIC_AL
 target_link_libraries(dwarf-static PRIVATE ZLIB::ZLIB ${ZSTD_LIB})
 target_include_directories(dwarf-static PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
 add_library(libdwarf::dwarf-static ALIAS dwarf-static)

--- a/src/lib/libdwarfp/CMakeLists.txt
+++ b/src/lib/libdwarfp/CMakeLists.txt
@@ -85,13 +85,22 @@ add_library(libdwarf::dwarfp-static ALIAS dwarfp-static)
 
 configure_file(libdwarfp.pc.in libdwarfp.pc @ONLY)
 
-install(TARGETS dwarfp-static dwarfp-shared
+if(INSTALL_STATIC_LIBRARIES)
+  set(DWARFP_STATIC_LIB "dwarfp-static")
+endif()
+
+install(TARGETS dwarfp-shared ${DWARFP_STATIC_LIB}
         EXPORT libdwarfpTargets
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         )
+export(
+  TARGETS dwarfp-shared ${DWARFP_STATIC_LIB}
+  NAMESPACE libdwarfp::
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/libdwarfp-targets.cmake"
+)
 install(EXPORT libdwarfpTargets FILE libdwarfp-targets.cmake
         NAMESPACE libdwarfp::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libdwarfp")

--- a/src/lib/libdwarfp/CMakeLists.txt
+++ b/src/lib/libdwarfp/CMakeLists.txt
@@ -45,11 +45,7 @@ dwarf_pro_section.h
 dwarf_pro_types.h
 dwarf_pro_util.h)
 
-set_source_group(CONFIGURATION_FILES "Configuration Files"
-    "${PROJECT_SOURCE_DIR}/cmake/config.h.in"
-    "${PROJECT_BINARY_DIR}/config.h")
-
-add_library(dwarfp-shared SHARED ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+add_library(dwarfp-shared SHARED ${SOURCES} ${HEADERS})
 target_link_libraries(dwarfp-shared PRIVATE dwarf-shared)
 set_target_properties(dwarfp-shared PROPERTIES
                                     C_VISIBILITY_PRESET hidden

--- a/src/lib/libdwarfp/CMakeLists.txt
+++ b/src/lib/libdwarfp/CMakeLists.txt
@@ -49,49 +49,48 @@ set_source_group(CONFIGURATION_FILES "Configuration Files"
     "${PROJECT_SOURCE_DIR}/cmake/config.h.in"
     "${PROJECT_BINARY_DIR}/config.h")
 
-if (BUILD_SHARED)
-    if(NOT BUILD_DWARFGEN)
-      set(CMAKE_C_VISIBILITY_PRESET hidden)
-    endif()
-    set(DEFS LIBDWARF_BUILD PIC)
-else()
-    set(DEFS LIBDWARF_STATIC)
-endif()
+add_library(dwarfp-shared SHARED ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+target_link_libraries(dwarfp-shared PRIVATE dwarf-shared)
+set_target_properties(dwarfp-shared PROPERTIES
+                                    C_VISIBILITY_PRESET hidden
+                                    VISIBILITY_INLINES_HIDDEN TRUE
+                                    OUTPUT_NAME "dwarfp"
+                                    EXPORT_NAME "dwarfp"
+                                    VERSION "${PROJECT_VERSION}"
+                                    SOVERSION "${PROJECT_VERSION_MAJOR}"
+                                    PUBLIC_HEADER "libdwarfp.h"
+                                    )
+target_compile_definitions(dwarfp-shared PRIVATE LIBDWARF_BUILD PUBLIC PIC)
+target_include_directories(dwarfp-shared PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarfp>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+set_folder(dwarfp-shared src/lib/libdwarfp)
+dwarf_common_options(dwarfp-shared)
+add_library(libdwarf::dwarfp ALIAS dwarfp-shared)
 
-if (BUILD_SHARED)
-    add_library(dwarfp SHARED ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
-    target_link_libraries(dwarfp PRIVATE dwarf-shared)
-    add_library(libdwarf::dwarfp-shared ALIAS dwarfp)
-else()
-    add_library(dwarfp STATIC ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
-    target_link_libraries(dwarfp PRIVATE dwarf-static)
-    add_library(libdwarf::dwarfp-static ALIAS dwarfp)
-endif()
-# Macos needs the PRIVATE too using APPLE
-# needed with MINGW OR MSYS OR WIN32 OR APPLE
-# allowed everywhere.
-set_folder(dwarfp src/lib/libdwarfp)
-target_compile_definitions(dwarfp PUBLIC ${DEFS})
-dwarf_common_options(dwarfp)
-set_target_properties(dwarfp PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}")
 
-msvc_posix(dwarfp)
-set_target_properties(dwarfp PROPERTIES PUBLIC_HEADER "libdwarfp.h")
+add_library(dwarfp-static STATIC ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+target_link_libraries(dwarfp-static PRIVATE dwarf-static)
+set_target_properties(dwarfp-static PROPERTIES
+                                    POSITION_INDEPENDENT_CODE $<$<BOOL:${PIC_ALWAYS}>:ON>
+                                    OUTPUT_NAME "$<$<PLATFORM_ID:Windows>:dwarfp-static>$<$<NOT:$<PLATFORM_ID:Windows>>:dwarfp>"
+                                    EXPORT_NAME "dwarfp-static"
+                                    PUBLIC_HEADER "libdwarfp.h"
+                                    )
+target_compile_definitions(dwarfp-static PUBLIC LIBDWARF_STATIC $<$<BOOL:${PIC_ALWAYS}>:PIC>)
+target_include_directories(dwarfp-static PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarfp>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+set_folder(dwarfp-static src/lib/libdwarfp)
+dwarf_common_options(dwarfp-static)
+add_library(libdwarf::dwarfp-static ALIAS dwarfp-static)
 
-install(TARGETS dwarfp
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        )
-
-# The install has to be here, not in
-# ../CMakeLists.txt  to make install work properly
-# for cmake before cmake 3.13. This also works
-# for newer cmake.
 configure_file(libdwarfp.pc.in libdwarfp.pc @ONLY)
 
-install(TARGETS dwarfp  EXPORT libdwarfpTargets
+install(TARGETS dwarfp-static dwarfp-shared
+        EXPORT libdwarfpTargets
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/src/lib/libdwarfp/CMakeLists.txt
+++ b/src/lib/libdwarfp/CMakeLists.txt
@@ -60,21 +60,21 @@ endif()
 
 if (BUILD_SHARED)
     add_library(dwarfp SHARED ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+    target_link_libraries(dwarfp PRIVATE dwarf-shared)
     add_library(libdwarf::dwarfp-shared ALIAS dwarfp)
 else()
     add_library(dwarfp STATIC ${SOURCES} ${HEADERS} ${CONFIGURATION_FILES})
+    target_link_libraries(dwarfp PRIVATE dwarf-static)
     add_library(libdwarf::dwarfp-static ALIAS dwarfp)
 endif()
 # Macos needs the PRIVATE too using APPLE
 # needed with MINGW OR MSYS OR WIN32 OR APPLE
 # allowed everywhere.
-target_link_libraries(dwarfp PRIVATE dwarf)
 set_folder(dwarfp src/lib/libdwarfp)
 target_compile_definitions(dwarfp PUBLIC ${DEFS})
-target_compile_definitions(dwarfp PRIVATE _GNU_SOURCE)
+dwarf_common_options(dwarfp)
 set_target_properties(dwarfp PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}")
-target_compile_options(dwarfp PRIVATE ${DW_COMPILER_FLAGS}
-    ${DW_FWALL})
+
 msvc_posix(dwarfp)
 set_target_properties(dwarfp PROPERTIES PUBLIC_HEADER "libdwarfp.h")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,12 @@
 add_library(dwarf_tests INTERFACE)
 dwarf_common_options(dwarf_tests)
 target_compile_definitions(dwarf_tests INTERFACE ${DW_LIBDWARF_STATIC} TESTING LIBDWARF_BUILD)
-target_include_directories(dwarf_tests INTERFACE "${PROJECT_SOURCE_DIR}/src/lib/libdwarf" "${PROJECT_SOURCE_DIR}/src/lib/libdwarfp" "${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
+target_include_directories(dwarf_tests INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarf>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib/libdwarfp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/bin/dwarfdump>
+  )
 
   add_executable(selfteststring
     "${PROJECT_SOURCE_DIR}/test/test_dwarfstring.c"
@@ -34,6 +39,7 @@ target_include_directories(dwarf_tests INTERFACE "${PROJECT_SOURCE_DIR}/src/lib/
   add_test(NAME selftest_linkedtopath COMMAND selftest_linkedtopath)
 
   add_executable(selftestlname "${PROJECT_SOURCE_DIR}/test/test_lname.c")
+  target_link_libraries(selftestlname PRIVATE dwarf_tests)
   add_test(NAME selftestlname COMMAND selftestlname -f "${PROJECT_SOURCE_DIR}")
 
   add_executable(selfgetopttest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(dwarf_tests INTERFACE)
-target_compile_definitions(dwarf_tests INTERFACE ${DW_LIBDWARF_STATIC} _GNU_SOURCE TESTING LIBDWARF_BUILD)
-target_compile_options(dwarf_tests INTERFACE ${DW_FWALL})
+dwarf_common_options(dwarf_tests)
+target_compile_definitions(dwarf_tests INTERFACE ${DW_LIBDWARF_STATIC} TESTING LIBDWARF_BUILD)
 target_include_directories(dwarf_tests INTERFACE "${PROJECT_SOURCE_DIR}/src/lib/libdwarf" "${PROJECT_SOURCE_DIR}/src/lib/libdwarfp" "${PROJECT_SOURCE_DIR}/src/bin/dwarfdump")
 
   add_executable(selfteststring
@@ -143,12 +143,12 @@ target_include_directories(dwarf_tests INTERFACE "${PROJECT_SOURCE_DIR}/src/lib/
 
   add_executable(selfmachouniversal
     "${PROJECT_SOURCE_DIR}/test/test_macho_universal.c")
-  target_link_libraries(selfmachouniversal PRIVATE dwarf_tests dwarf)
+  target_link_libraries(selfmachouniversal PRIVATE dwarf_tests dwarf-shared)
   add_test(NAME selfmachouniversal COMMAND selfmachouniversal)
 
   add_executable(selfcompress64
     "${PROJECT_SOURCE_DIR}/test/test_compress64.c")
-  target_link_libraries(selfcompress64 PRIVATE dwarf_tests dwarf)
+  target_link_libraries(selfcompress64 PRIVATE dwarf_tests dwarf-static)
   add_test(NAME selfcompress64 COMMAND selfcompress64)
 
 if(NOT WIN32)


### PR DESCRIPTION
Thank you for this nice library.

One problem with the current compilation is that, depending on how `dwarfgen` is compiled, the shared library may be compiled with hidden visibility or without it. To fix this, the libraries are now always compiled as both shared and static libraries, and `dwarfgen` is linked against the static library. The shared library is therefore always compiled with hidden visibility.

Since we now compile both shared and static libraries, it is possible to install both. I also added an option to install only the shared library.
